### PR TITLE
Remove duplicate submit_application view

### DIFF
--- a/apps/consultants/views.py
+++ b/apps/consultants/views.py
@@ -40,30 +40,3 @@ def submit_application(request):
         'form': form,
         'is_editing': application is not None and application.status == 'draft',
     })
-###########################################
-@login_required
-def submit_application(request):
-    # Get existing application if one exists
-    application = Consultant.objects.filter(user=request.user).first()
-
-    if application and application.status != 'draft':
-        return redirect('dashboard')  # Prevent edits if not draft
-
-    form = ConsultantForm(
-        request.POST or None,
-        request.FILES or None,
-        instance=application
-    )
-
-    if request.method == 'POST':
-        if form.is_valid():
-            consultant = form.save(commit=False)
-            consultant.user = request.user
-            consultant.status = 'submitted'
-            consultant.save()
-            return redirect('dashboard')
-
-    return render(request, 'consultants/application_form.html', {
-        'form': form,
-        'is_editing': application is not None and application.status == 'draft',
-    })


### PR DESCRIPTION
## Summary
- remove the duplicate consultants.submit_application view so the version that handles draft vs submit actions remains

## Testing
- python manage.py test
- python manage.py shell <<'PY'  # smoke test draft/save and submit flows


------
https://chatgpt.com/codex/tasks/task_e_68d392f435ac8326b0ec37c02d50a463