### PR TITLE
Fix consultant application handling and tests

### DIFF
--- a/apps/consultants/forms.py
+++ b/apps/consultants/forms.py
@@ -9,11 +9,15 @@ class ConsultantForm(forms.ModelForm):
             'dob': forms.DateInput(attrs={'type': 'date'}),
         }
 
-def clean(self):
+    def clean(self):
         cleaned_data = super().clean()
         required_docs = [
-            'photo', 'id_document', 'cv', 'police_clearance',
-            'qualifications', 'business_certificate'
+            'photo',
+            'id_document',
+            'cv',
+            'police_clearance',
+            'qualifications',
+            'business_certificate',
         ]
 
         for field in required_docs:
@@ -21,7 +25,7 @@ def clean(self):
             if file:
                 if file.size > 2 * 1024 * 1024:  # 2MB
                     self.add_error(field, "File size must be under 2MB.")
-                if not file.content_type in ['application/pdf', 'image/jpeg', 'image/png']:
+                if file.content_type not in ['application/pdf', 'image/jpeg', 'image/png']:
                     self.add_error(field, "Only PDF, JPG, or PNG files are allowed.")
             else:
                 self.add_error(field, "This document is required.")

--- a/apps/consultants/tests.py
+++ b/apps/consultants/tests.py
@@ -1,3 +1,96 @@
-from django.test import TestCase
+import io
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+from PIL import Image
+
+from .forms import ConsultantForm
+from .models import Consultant
+
+
+def _create_test_image(filename='photo.png'):
+    image = Image.new('RGB', (1, 1), 'white')
+    buffer = io.BytesIO()
+    image.save(buffer, format='PNG')
+    return SimpleUploadedFile(filename, buffer.getvalue(), content_type='image/png')
+
+
+def _create_pdf(name):
+    return SimpleUploadedFile(name, b'%PDF-1.4 test pdf', content_type='application/pdf')
+
+
+def _valid_form_data():
+    return {
+        'full_name': 'Jane Doe',
+        'id_number': '1234567890',
+        'dob': '1990-01-01',
+        'gender': 'F',
+        'nationality': 'Country',
+        'email': 'jane@example.com',
+        'phone_number': '+123456789',
+        'business_name': 'Jane Consulting',
+        'registration_number': 'REG123',
+    }
+
+
+def _valid_form_files():
+    return {
+        'photo': _create_test_image(),
+        'id_document': _create_pdf('id.pdf'),
+        'cv': _create_pdf('cv.pdf'),
+        'police_clearance': _create_pdf('police.pdf'),
+        'qualifications': _create_pdf('qualifications.pdf'),
+        'business_certificate': _create_pdf('certificate.pdf'),
+    }
+
+
+class ConsultantFormTests(TestCase):
+
+    def test_rejects_invalid_document_types(self):
+        files = _valid_form_files()
+        files['id_document'] = SimpleUploadedFile('id.txt', b'invalid', content_type='text/plain')
+
+        form = ConsultantForm(data=_valid_form_data(), files=files)
+
+        self.assertFalse(form.is_valid())
+        self.assertIn('Only PDF, JPG, or PNG files are allowed.', form.errors['id_document'])
+
+
+class SubmitApplicationViewTests(TestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(
+            username='applicant',
+            password='strong-password',
+            email='applicant@example.com',
+        )
+        self.client.force_login(self.user)
+        self.url = reverse('submit_application')
+
+    def _post_payload(self, **overrides):
+        data = {
+            **_valid_form_data(),
+            **_valid_form_files(),
+            'action': 'draft',
+        }
+        data.update(overrides)
+        return data
+
+    def test_can_save_application_as_draft(self):
+        response = self.client.post(self.url, self._post_payload(), follow=True)
+
+        self.assertRedirects(response, reverse('dashboard'))
+        consultant = Consultant.objects.get(user=self.user)
+        self.assertEqual(consultant.status, 'draft')
+
+    def test_submit_action_marks_application_as_submitted(self):
+        response = self.client.post(
+            self.url,
+            self._post_payload(action='submit'),
+            follow=True,
+        )
+
+        self.assertRedirects(response, reverse('dashboard'))
+        consultant = Consultant.objects.get(user=self.user)
+        self.assertEqual(consultant.status, 'submitted')

--- a/apps/consultants/views.py
+++ b/apps/consultants/views.py
@@ -1,17 +1,14 @@
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 
 from .forms import ConsultantForm
 from .models import Consultant
-from django.contrib import messages
 
 
-
-
-
-############################################
 @login_required
 def submit_application(request):
+    """Allow consultants to create or update their application."""
     application = Consultant.objects.filter(user=request.user).first()
 
     if application and application.status != 'draft':
@@ -21,7 +18,7 @@ def submit_application(request):
     form = ConsultantForm(request.POST or None, request.FILES or None, instance=application)
 
     if request.method == 'POST':
-        action = request.POST.get('action')  # 'draft' or 'submit'
+        action = request.POST.get('action')
 
         if form.is_valid():
             consultant = form.save(commit=False)
@@ -36,34 +33,11 @@ def submit_application(request):
 
             return redirect('dashboard')
 
-    return render(request, 'consultants/application_form.html', {
-        'form': form,
-        'is_editing': application is not None and application.status == 'draft',
-    })
-###########################################
-@login_required
-def submit_application(request):
-    # Get existing application if one exists
-    application = Consultant.objects.filter(user=request.user).first()
-
-    if application and application.status != 'draft':
-        return redirect('dashboard')  # Prevent edits if not draft
-
-    form = ConsultantForm(
-        request.POST or None,
-        request.FILES or None,
-        instance=application
+    return render(
+        request,
+        'consultants/application_form.html',
+        {
+            'form': form,
+            'is_editing': application is not None and application.status == 'draft',
+        },
     )
-
-    if request.method == 'POST':
-        if form.is_valid():
-            consultant = form.save(commit=False)
-            consultant.user = request.user
-            consultant.status = 'submitted'
-            consultant.save()
-            return redirect('dashboard')
-
-    return render(request, 'consultants/application_form.html', {
-        'form': form,
-        'is_editing': application is not None and application.status == 'draft',
-    })


### PR DESCRIPTION
## Summary
- unify the consultant submission view so draft and submit actions update status correctly and provide user feedback
- fix the consultant form clean method so document validation runs as intended
- add tests covering document validation and draft/submit behaviour for consultant applications

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d2709ad4b88326b146065b1e50c2e3