### PR TITLE
Align seed users with reviewer groups and add regression test

### DIFF
--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -1,3 +1,16 @@
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
 from django.test import TestCase
 
-# Create your tests here.
+from apps.decisions.views import is_reviewer
+
+
+class SeedUsersCommandTests(TestCase):
+    def test_seeded_reviewer_matches_access_control(self):
+        """Ensure the seed command populates reviewer groups correctly."""
+
+        call_command("seed_groups")
+        call_command("seed_users")
+
+        reviewer = get_user_model().objects.get(username="officer1")
+        self.assertTrue(is_reviewer(reviewer))


### PR DESCRIPTION
## Summary
- update the seed_users management command to rely on the groups from seed_groups and ensure reviewer accounts join the official reviewer groups
- mark reviewer fixtures as staff and surface a clear error when prerequisite groups are missing
- add a regression test confirming a seeded reviewer satisfies the is_reviewer access check

## Testing
- python manage.py test apps.users.tests.SeedUsersCommandTests


------
https://chatgpt.com/codex/tasks/task_e_68d3eac1509483268a83851f0b3a2227