### PR TITLE
Configure pytest for Django

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = backend.settings


### PR DESCRIPTION
## Summary
- add a pytest.ini file that sets DJANGO_SETTINGS_MODULE to backend.settings so pytest-django loads the correct configuration

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db4f8babfc832680569bddf45cb0a7