### PR TITLE
Configure WhiteNoise for static files

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -137,6 +138,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # Static & Media Configuration
 STATIC_URL = '/static/'
 STATICFILES_DIRS = [BASE_DIR / 'static']
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ packaging==25.0
 pillow==11.3.0
 psycopg2-binary==2.9.10
 sqlparse==0.5.3
+whitenoise==6.8.2


### PR DESCRIPTION
## Summary
- add WhiteNoise to the Python dependencies for Render deployments
- enable WhiteNoise middleware and compressed manifest static file storage in Django settings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db519c5a8083268f1024f91fb886a1