### PR TITLE
Redirect reviewer dashboard to officer queue

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -3,6 +3,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.decorators import login_required
 
 from apps.consultants.models import Consultant
+from apps.decisions.views import is_reviewer
 
 def register(request):
     if request.method == 'POST':
@@ -16,12 +17,16 @@ def register(request):
 
 @login_required
 def dashboard(request):
+    reviewer = is_reviewer(request.user)
 
+    if reviewer:
+        return redirect('officer_applications_list')
 
     application = Consultant.objects.filter(user=request.user).first()
 
     return render(request, 'dashboard.html', {
-        'application': application
+        'application': application,
+        'is_reviewer': reviewer,
     })
 def home_view(request):
     return render(request, 'home.html')

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -16,7 +16,13 @@
     {% csrf_token %}
     <button type="submit">Logout</button>
   </form>
-  
+
+  {% if is_reviewer %}
+    <p>
+      <a href="{% url 'officer_applications_list' %}">Review applications</a>
+    </p>
+  {% endif %}
+
 <h2>Dashboard for {{ user.username }}</h2>
 
 {% if application %}


### PR DESCRIPTION
## Summary
- redirect staff reviewers away from the consultant dashboard to the officer applications queue
- expose the reviewer flag to the dashboard template and add a link back to the officer queue

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68db57756b508326a484948ada6316cb