### PR TITLE
Show save draft option for new consultant applications

### DIFF
--- a/apps/consultants/views.py
+++ b/apps/consultants/views.py
@@ -39,4 +39,5 @@ def submit_application(request):
     return render(request, 'consultants/application_form.html', {
         'form': form,
         'is_editing': application is not None and application.status == 'draft',
+        'show_save_draft': application is None or application.status == 'draft',
     })

--- a/templates/consultants/application_form.html
+++ b/templates/consultants/application_form.html
@@ -11,7 +11,7 @@
     {{ form.as_p }}
 
     <div class="form-actions">
-      {% if is_editing %}
+      {% if show_save_draft %}
         <button type="submit" name="action" value="draft" class="btn-secondary">Save draft</button>
       {% endif %}
       <button type="submit" name="action" value="submit" class="btn-primary">Submit application</button>


### PR DESCRIPTION
## Summary
- ensure the consultant application view exposes a flag so drafts can be saved when creating a new application
- render the Save draft button whenever a user is creating or editing a draft application

## Testing
- DJANGO_SETTINGS_MODULE=backend.settings pytest apps/consultants/tests.py *(fails: django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.)*

------
https://chatgpt.com/codex/tasks/task_e_68db6088ad5c8326a451d8768e555ad0