### PR TITLE
Implement vetting dashboard view and routing

### DIFF
--- a/apps/vetting/urls.py
+++ b/apps/vetting/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from .views import vetting_dashboard
+
+
+urlpatterns = [
+    path("", vetting_dashboard, name="vetting_dashboard"),
+]

--- a/apps/vetting/views.py
+++ b/apps/vetting/views.py
@@ -1,3 +1,36 @@
-from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseForbidden
+from django.shortcuts import get_object_or_404, redirect, render
 
-# Create your views here.
+from apps.consultants.models import Consultant
+
+
+@login_required
+def vetting_dashboard(request):
+    """Display consultant applications for vetting staff to review."""
+
+    if not request.user.groups.filter(name="vetting").exists():
+        return HttpResponseForbidden()
+
+    consultants = Consultant.objects.all().order_by("full_name")
+
+    if request.method == "POST":
+        consultant_id = request.POST.get("consultant_id")
+        action = request.POST.get("action")
+
+        if consultant_id and action:
+            consultant = get_object_or_404(Consultant, pk=consultant_id)
+
+            status_map = {
+                "approve": "approved",
+                "reject": "rejected",
+                "vet": "vetted",
+            }
+
+            new_status = status_map.get(action)
+            if new_status:
+                consultant.status = new_status
+                consultant.save()
+                return redirect("vetting_dashboard")
+
+    return render(request, "vetting/dashboard.html", {"consultants": consultants})

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -24,5 +24,6 @@ urlpatterns = [
     path('', include('apps.users.urls')),
     path('consultants/', include('apps.consultants.urls')),
     path('officer/', include('apps.decisions.urls')),  # 👈 staff review routes
+    path('vetting/', include('apps.vetting.urls')),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/templates/vetting/dashboard.html
+++ b/templates/vetting/dashboard.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block title %}Vetting Dashboard{% endblock %}
+
+{% block content %}
+<h1>Vetting Dashboard</h1>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for consultant in consultants %}
+        <tr>
+            <td>{{ consultant.full_name }}</td>
+            <td>{{ consultant.get_status_display }}</td>
+        </tr>
+        {% empty %}
+        <tr>
+            <td colspan="2">No consultants found.</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a vetting dashboard view that restricts access to the vetting group and updates consultant statuses
- create a vetting URLConf and template to display consultant submissions
- register the vetting URLs with the project router

## Testing
- python manage.py test apps.vetting

------
https://chatgpt.com/codex/tasks/task_e_68dce208c05c832688a360c460d20898