### PR TITLE
Add reviewer decisions dashboard view and tests

### DIFF
--- a/apps/decisions/tests.py
+++ b/apps/decisions/tests.py
@@ -4,10 +4,12 @@ import tempfile
 from datetime import date
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from apps.consultants.models import Consultant
+from .models import ApplicationAction
 
 
 class ApplicationDecisionDocumentTests(TestCase):
@@ -79,3 +81,90 @@ class ApplicationDecisionDocumentTests(TestCase):
 
         response = self.client.get(url)
         self.assertContains(response, "Rejection letter")
+
+
+class DecisionsDashboardViewTests(TestCase):
+    def setUp(self):
+        self.UserModel = get_user_model()
+        self.reviewer_group, _ = Group.objects.get_or_create(name="BackOffice")
+
+        self.reviewer = self.UserModel.objects.create_user(
+            username="reviewer",
+            email="reviewer@example.com",
+            password="pass1234",
+        )
+        self.reviewer.groups.add(self.reviewer_group)
+
+        self.client.login(username="reviewer", password="pass1234")
+
+        self.consultant_user = self.UserModel.objects.create_user(
+            username="consultant",
+            email="consultant@example.com",
+            password="pass1234",
+        )
+        self.consultant_vetted = Consultant.objects.create(
+            user=self.consultant_user,
+            full_name="Vetted Applicant",
+            id_number="ID0001",
+            dob=date(1990, 1, 1),
+            gender="F",
+            nationality="Exampleland",
+            email="consultant@example.com",
+            phone_number="123456789",
+            business_name="Vet Consulting",
+            registration_number="REG-123",
+            status="vetted",
+        )
+        self.consultant_submitted = Consultant.objects.create(
+            user=self.UserModel.objects.create_user(
+                username="submitted", email="submitted@example.com", password="pass1234"
+            ),
+            full_name="Submitted Applicant",
+            id_number="ID0002",
+            dob=date(1992, 5, 5),
+            gender="M",
+            nationality="Exampleland",
+            email="submitted@example.com",
+            phone_number="987654321",
+            business_name="Sub Consulting",
+            registration_number="REG-456",
+            status="submitted",
+        )
+
+    def test_reviewer_can_access_dashboard(self):
+        response = self.client.get(reverse("decisions_dashboard"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Vetted Applicant")
+        self.assertNotContains(response, "Submitted Applicant")
+
+    def test_non_reviewer_gets_403(self):
+        other_user = self.UserModel.objects.create_user(
+            username="nonreviewer", email="non@example.com", password="pass1234"
+        )
+        self.client.logout()
+        self.client.login(username="nonreviewer", password="pass1234")
+
+        response = self.client.get(reverse("decisions_dashboard"))
+        self.assertEqual(response.status_code, 403)
+
+    def test_reviewer_can_record_action(self):
+        response = self.client.post(
+            reverse("decisions_dashboard"),
+            data={
+                "consultant_id": self.consultant_vetted.pk,
+                "action": "vetted",
+                "notes": "Checked and ready.",
+            },
+            follow=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.consultant_vetted.refresh_from_db()
+        self.assertEqual(self.consultant_vetted.status, "vetted")
+        self.assertTrue(
+            ApplicationAction.objects.filter(
+                consultant=self.consultant_vetted,
+                actor=self.reviewer,
+                action="vetted",
+            ).exists()
+        )

--- a/apps/decisions/urls.py
+++ b/apps/decisions/urls.py
@@ -1,14 +1,13 @@
 from django.urls import path
+
 from . import views
 
 urlpatterns = [
-    path('applications/', views.applications_list, name='officer_applications_list'),
-    path('applications/<int:pk>/', views.application_detail, name='officer_application_detail'),
-]
-from django.urls import path
-from . import views
-
-urlpatterns = [
-    path('applications/', views.applications_list, name='officer_applications_list'),
-    path('applications/<int:pk>/', views.application_detail, name='officer_application_detail'),
+    path("dashboard/", views.decisions_dashboard, name="decisions_dashboard"),
+    path("applications/", views.applications_list, name="officer_applications_list"),
+    path(
+        "applications/<int:pk>/",
+        views.application_detail,
+        name="officer_application_detail",
+    ),
 ]

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -20,6 +20,7 @@
     {% if is_reviewer %}
     <div class="form-actions">
       <a class="btn-primary" href="{% url 'officer_applications_list' %}">Review applications</a>
+      <a class="btn-secondary" href="{% url 'decisions_dashboard' %}">Decisions dashboard</a>
     </div>
     {% endif %}
   </section>

--- a/templates/officer/decisions_dashboard.html
+++ b/templates/officer/decisions_dashboard.html
@@ -1,0 +1,60 @@
+{% extends 'base.html' %}
+
+{% block title %}Decisions dashboard{% endblock %}
+
+{% block content %}
+<div class="page-stack">
+  {% if messages %}
+  <section class="data-card" aria-live="polite">
+    <ul class="message-list">
+      {% for message in messages %}
+      <li>{{ message }}</li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
+
+  <section class="data-card">
+    <div class="card-header">
+      <h2>Applications requiring decisions</h2>
+      <p class="card-subtitle">Review recently vetted submissions and record the final outcome.</p>
+    </div>
+
+    {% if consultants %}
+    <div class="table-wrapper">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th scope="col">Consultant</th>
+            <th scope="col">Status</th>
+            <th scope="col">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for consultant in consultants %}
+          <tr>
+            <td>
+              <strong>{{ consultant.full_name }}</strong><br>
+              <span class="muted">{{ consultant.business_name }}</span>
+            </td>
+            <td>{{ consultant.get_status_display|default:consultant.status|title }}</td>
+            <td>
+              <form method="post" class="inline-form">
+                {% csrf_token %}
+                <input type="hidden" name="consultant_id" value="{{ consultant.pk }}">
+                {{ form.action.as_widget }}
+                {{ form.notes.as_widget }}
+                <button type="submit" class="btn-primary">Record</button>
+              </form>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% else %}
+    <p class="card-subtitle">There are currently no vetted applications awaiting a decision.</p>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a reviewer-only decisions dashboard that lists vetted applications and records actions
- register the dashboard route and expose it from the staff navigation
- add decision dashboard tests covering permissions and action handling

## Testing
- python manage.py test apps.decisions

------
https://chatgpt.com/codex/tasks/task_e_68dce5b509d08326b5118d21d0a858c0