### PR TITLE
Add certificates dashboard for consultants

### DIFF
--- a/apps/certificates/tests.py
+++ b/apps/certificates/tests.py
@@ -1,3 +1,84 @@
-from django.test import TestCase
+from datetime import date
 
-# Create your tests here.
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.consultants.models import Consultant
+
+
+class CertificatesDashboardViewTests(TestCase):
+    def setUp(self):
+        self.user_model = get_user_model()
+        self.user = self.user_model.objects.create_user(
+            "consultant_user", password="strong-password"
+        )
+        self.dashboard_url = reverse("certificates:certificates_dashboard")
+
+    def _create_consultant(self, user, **overrides):
+        defaults = {
+            "full_name": "Sample Consultant",
+            "id_number": "ID123456",
+            "dob": date(1990, 1, 1),
+            "gender": "M",
+            "nationality": "Testland",
+            "email": "consultant@example.com",
+            "phone_number": "1234567890",
+            "business_name": "Consulting LLC",
+            "registration_number": "REG123",
+            "status": "approved",
+        }
+        defaults.update(overrides)
+        return Consultant.objects.create(user=user, **defaults)
+
+    def test_dashboard_requires_authentication(self):
+        response = self.client.get(self.dashboard_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login/", response["Location"])
+
+    def test_dashboard_handles_users_without_consultant_profile(self):
+        self.client.force_login(self.user)
+
+        response = self.client.get(self.dashboard_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.context["consultant"])
+        self.assertContains(response, "could not find an application", status_code=200)
+
+    def test_dashboard_displays_documents_for_logged_in_consultant(self):
+        certificate_file = SimpleUploadedFile(
+            "approval.pdf", b"certificate", content_type="application/pdf"
+        )
+        rejection_file = SimpleUploadedFile(
+            "rejection.pdf", b"rejection", content_type="application/pdf"
+        )
+
+        consultant = self._create_consultant(
+            self.user,
+            full_name="Primary Consultant",
+            certificate_pdf=certificate_file,
+            rejection_letter=rejection_file,
+        )
+
+        other_user = self.user_model.objects.create_user(
+            "other_user", password="strong-password"
+        )
+        self._create_consultant(
+            other_user,
+            full_name="Other Consultant",
+            certificate_pdf=SimpleUploadedFile(
+                "other.pdf", b"other", content_type="application/pdf"
+            ),
+        )
+
+        self.client.force_login(self.user)
+        response = self.client.get(self.dashboard_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["consultant"], consultant)
+        self.assertContains(response, "Approval certificate")
+        self.assertContains(response, "Rejection letter")
+        self.assertContains(response, "approval.pdf")
+        self.assertContains(response, "rejection.pdf")
+        self.assertNotContains(response, "Other Consultant")

--- a/apps/certificates/urls.py
+++ b/apps/certificates/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from . import views
+
+
+app_name = "certificates"
+
+
+urlpatterns = [
+    path("", views.certificates_dashboard, name="certificates_dashboard"),
+]

--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -1,3 +1,17 @@
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 
-# Create your views here.
+from apps.consultants.models import Consultant
+
+
+@login_required
+def certificates_dashboard(request):
+    consultant = Consultant.objects.filter(user=request.user).first()
+
+    return render(
+        request,
+        "certificates/dashboard.html",
+        {
+            "consultant": consultant,
+        },
+    )

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('apps.users.urls')),
     path('consultants/', include('apps.consultants.urls')),
+    path('certificates/', include(('apps.certificates.urls', 'certificates'), namespace='certificates')),
     path('officer/', include('apps.decisions.urls')),  # 👈 staff review routes
     path('vetting/', include('apps.vetting.urls')),
 

--- a/templates/certificates/dashboard.html
+++ b/templates/certificates/dashboard.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+
+{% block title %}Decision documents{% endblock %}
+
+{% block content %}
+<div class="page-stack">
+  <section class="data-card">
+    <h2>Your decision documents</h2>
+    <p class="card-subtitle">Access approval certificates or rejection letters that have been generated for your application.</p>
+
+    {% if consultant %}
+    <div class="card-header">
+      <h3>{{ consultant.full_name }}</h3>
+      <span class="status-pill">{{ consultant.status|title }}</span>
+    </div>
+
+    {% if consultant.certificate_pdf or consultant.rejection_letter %}
+    <ul class="document-list">
+      {% if consultant.certificate_pdf %}
+      <li>Approval certificate — <a href="{{ consultant.certificate_pdf.url }}" target="_blank" rel="noopener">Download</a></li>
+      {% endif %}
+      {% if consultant.rejection_letter %}
+      <li>Rejection letter — <a href="{{ consultant.rejection_letter.url }}" target="_blank" rel="noopener">Download</a></li>
+      {% endif %}
+    </ul>
+    {% else %}
+    <p class="card-subtitle">Decision documents will appear here once generated.</p>
+    {% endif %}
+    {% else %}
+    <p class="card-subtitle">We could not find an application linked to your account yet.</p>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement a certificates dashboard view that exposes a consultant's decision documents
- add URL routing and template to render certificate and rejection links for the logged-in user
- create unit tests covering authentication requirements and document visibility

## Testing
- python manage.py test apps.certificates

------
https://chatgpt.com/codex/tasks/task_e_68dce809b90c8326a086c9f8888b22eb