### PR TITLE
Fix logout redirect to login view

### DIFF
--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -1,6 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.test import TestCase
+from django.urls import reverse
 
 from apps.decisions.views import is_reviewer
 
@@ -14,3 +15,15 @@ class SeedUsersCommandTests(TestCase):
 
         reviewer = get_user_model().objects.get(username="officer1")
         self.assertTrue(is_reviewer(reviewer))
+
+
+class LogoutRedirectTests(TestCase):
+    def test_logout_redirects_to_login(self):
+        """The logout view should redirect to the login page."""
+
+        response = self.client.post(reverse("logout"))
+        self.assertRedirects(
+            response,
+            reverse("login"),
+            fetch_redirect_response=False,
+        )

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from django.core.exceptions import ImproperlyConfigured
+from django.urls import reverse_lazy
 
 import dj_database_url
 
@@ -106,7 +107,7 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'backend.urls'
 LOGIN_REDIRECT_URL = '/dashboard/'
-LOGOUT_REDIRECT_URL = '/accounts/login/'
+LOGOUT_REDIRECT_URL = reverse_lazy('login')
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
## Summary
- update the logout redirect configuration to reuse the existing login view
- add a regression test that ensures the logout view redirects to the login page

## Testing
- python manage.py test apps.users

------
https://chatgpt.com/codex/tasks/task_e_68dd29a745948326becadafa74f1247c