### PR TITLE
Display dashboard form errors and test missing action

### DIFF
--- a/apps/decisions/tests.py
+++ b/apps/decisions/tests.py
@@ -212,3 +212,15 @@ class DecisionsDashboardViewTests(TestCase):
                 action="vetted",
             ).exists()
         )
+
+    def test_missing_action_displays_error(self):
+        response = self.client.post(
+            reverse("decisions_dashboard"),
+            data={
+                "consultant_id": self.consultant_vetted.pk,
+                "notes": "Needs a decision.",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "This field is required.")

--- a/templates/officer/decisions_dashboard.html
+++ b/templates/officer/decisions_dashboard.html
@@ -42,8 +42,45 @@
               <form method="post" class="inline-form">
                 {% csrf_token %}
                 <input type="hidden" name="consultant_id" value="{{ consultant.pk }}">
-                {{ form.action.as_widget }}
-                {{ form.notes.as_widget }}
+                {% if form.non_field_errors %}
+                <div class="form-errors" role="alert">
+                  {{ form.non_field_errors }}
+                </div>
+                {% endif %}
+
+                {% with row_index=forloop.counter|stringformat:"s" %}
+                {% with action_field=form.action %}
+                {% with action_error_id="action-error-"|add:row_index %}
+                <div class="form-field{% if action_field.errors %} has-error{% endif %}" role="group" aria-labelledby="{{ action_field.id_for_label }}-label"{% if action_field.errors %} aria-describedby="{{ action_error_id }}"{% endif %}>
+                  <label id="{{ action_field.id_for_label }}-label" for="{{ action_field.id_for_label }}">{{ action_field.label }}</label>
+                  {{ action_field }}
+                  {% if action_field.errors %}
+                  <div class="field-errors" id="{{ action_error_id }}" role="alert" aria-live="assertive">
+                    {% for error in action_field.errors %}
+                    <p>{{ error }}</p>
+                    {% endfor %}
+                  </div>
+                  {% endif %}
+                </div>
+                {% endwith %}
+                {% endwith %}
+
+                {% with notes_field=form.notes %}
+                {% with notes_error_id="notes-error-"|add:row_index %}
+                <div class="form-field{% if notes_field.errors %} has-error{% endif %}" role="group" aria-labelledby="{{ notes_field.id_for_label }}-label"{% if notes_field.errors %} aria-describedby="{{ notes_error_id }}"{% endif %}>
+                  <label id="{{ notes_field.id_for_label }}-label" for="{{ notes_field.id_for_label }}">{{ notes_field.label }}</label>
+                  {{ notes_field }}
+                  {% if notes_field.errors %}
+                  <div class="field-errors" id="{{ notes_error_id }}" role="alert" aria-live="assertive">
+                    {% for error in notes_field.errors %}
+                    <p>{{ error }}</p>
+                    {% endfor %}
+                  </div>
+                  {% endif %}
+                </div>
+                {% endwith %}
+                {% endwith %}
+                {% endwith %}
                 <button type="submit" class="btn-primary">Record</button>
               </form>
             </td>


### PR DESCRIPTION
## Summary
- surface non-field and field-level validation feedback inline on the decisions dashboard
- add semantic error markup to associate validation messages with their respective inputs
- cover posting the dashboard form without an action to confirm the validation message is rendered

## Testing
- pytest apps/decisions/tests.py *(fails: settings not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4735f2b083268806ae32b046da3c