### PR TITLE
Add submitted documents section to consultant dashboard

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -24,9 +24,30 @@ def dashboard(request):
 
     application = Consultant.objects.filter(user=request.user).first()
 
+    document_fields = []
+    document_field_labels = [
+        ('photo', 'Profile photo'),
+        ('id_document', 'ID document'),
+        ('cv', 'Curriculum vitae'),
+        ('police_clearance', 'Police clearance'),
+        ('qualifications', 'Qualifications'),
+        ('business_certificate', 'Business certificate'),
+    ]
+
+    if application:
+        for field_name, label in document_field_labels:
+            file_field = getattr(application, field_name)
+            if file_field:
+                document_fields.append({
+                    'name': field_name,
+                    'label': label,
+                    'file': file_field,
+                })
+
     return render(request, 'dashboard.html', {
         'application': application,
         'is_reviewer': reviewer,
+        'document_fields': document_fields,
     })
 def home_view(request):
     return render(request, 'home.html')

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -42,6 +42,15 @@
       <li><strong>Submitted:</strong> {{ application.submitted_at }}</li>
     </ul>
 
+    {% if document_fields %}
+    <h4>Submitted documents</h4>
+    <ul class="document-list">
+      {% for document in document_fields %}
+      <li>{{ document.label }} — <a href="{{ document.file.url }}" target="_blank" rel="noopener">Download</a></li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+
     {% if application.certificate_pdf or application.rejection_letter %}
     <h4>Decision documents</h4>
     <ul class="document-list">


### PR DESCRIPTION
## Summary
- add document metadata to the dashboard view so submitted files can be listed
- render a submitted documents section in the dashboard when uploads exist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd510546088326b69eb56e51365076