### PR TITLE
Enforce role-based access on dashboards

### DIFF
--- a/apps/certificates/views.py
+++ b/apps/certificates/views.py
@@ -1,11 +1,12 @@
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 
 from apps.consultants.models import Consultant
+from apps.users.constants import UserRole as Roles
+from apps.users.permissions import role_required
 
 
-@login_required
+@role_required(Roles.CONSULTANT)
 def certificates_dashboard(request):
     consultant = Consultant.objects.filter(user=request.user).first()
 

--- a/apps/consultants/views.py
+++ b/apps/consultants/views.py
@@ -1,13 +1,14 @@
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 from django.utils import timezone
 
 from .forms import ConsultantForm
 from .models import Consultant
+from apps.users.constants import UserRole as Roles
+from apps.users.permissions import role_required
 
 
-@login_required
+@role_required(Roles.CONSULTANT)
 def submit_application(request):
     application = Consultant.objects.filter(user=request.user).first()
 

--- a/apps/decisions/views.py
+++ b/apps/decisions/views.py
@@ -16,6 +16,8 @@ from apps.certificates.services import (
 )
 from .forms import ActionForm
 from .models import ApplicationAction
+from apps.users.constants import UserRole as Roles
+from apps.users.permissions import user_has_role
 
 ACTION_MESSAGES = {
     "vetted": "Application has been vetted.",
@@ -23,22 +25,11 @@ ACTION_MESSAGES = {
     "rejected": "Application has been rejected.",
 }
 
-REVIEWER_GROUPS = {
-    'BackOffice',
-    'DISAgents',
-    'BoardCommittee',
-    'SeniorImmigration',
-    'Admins',
-}
+REVIEWER_ROLES = (Roles.BOARD, Roles.STAFF)
+
 
 def is_reviewer(user):
-    if not user.is_authenticated:
-        return False
-    # superusers always allowed
-    if user.is_superuser:
-        return True
-    # group membership check
-    return user.groups.filter(name__in=REVIEWER_GROUPS).exists()
+    return any(user_has_role(user, role) for role in REVIEWER_ROLES)
 
 def reviewer_required(view_func):
     @wraps(view_func)

--- a/apps/users/management/commands/seed_users.py
+++ b/apps/users/management/commands/seed_users.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.db.utils import OperationalError
 
-from apps.decisions.views import REVIEWER_GROUPS
+from apps.users.constants import UserRole, groups_for_roles
 
 PASSWORD = "Testpass123!"
 
@@ -44,7 +44,7 @@ class Command(BaseCommand):
                 )
             )
 
-        reviewer_groups = REVIEWER_GROUPS
+        reviewer_groups = groups_for_roles((UserRole.BOARD, UserRole.STAFF))
         user_model = get_user_model()
 
         for username, password, group_names in USERS:

--- a/apps/vetting/tests.py
+++ b/apps/vetting/tests.py
@@ -5,7 +5,7 @@ from django.test import TestCase, Client
 from django.contrib.auth.models import User, Group
 from django.urls import reverse
 from apps.consultants.models import Consultant
-from apps.users.constants import COUNTERSTAFF_GROUP_NAME
+from apps.users.constants import COUNTERSTAFF_GROUP_NAME, BOARD_COMMITTEE_GROUP_NAME
 
 
 class VettingDashboardViewTests(TestCase):
@@ -52,6 +52,17 @@ class VettingDashboardViewTests(TestCase):
         self.client.logout()
         other_user = User.objects.create_user(username='unauth', password='unauthpass')
         self.client.login(username='unauth', password='unauthpass')
+
+        response = self.client.get(reverse('vetting_dashboard'))
+        self.assertEqual(response.status_code, 403)
+
+    def test_board_member_receives_403(self):
+        self.client.logout()
+        board_user = User.objects.create_user(username='board', password='boardpass')
+        board_group, _ = Group.objects.get_or_create(name=BOARD_COMMITTEE_GROUP_NAME)
+        board_user.groups.add(board_group)
+
+        self.client.login(username='board', password='boardpass')
 
         response = self.client.get(reverse('vetting_dashboard'))
         self.assertEqual(response.status_code, 403)

--- a/apps/vetting/views.py
+++ b/apps/vetting/views.py
@@ -1,17 +1,13 @@
-from django.contrib.auth.decorators import login_required
-from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 
 from apps.consultants.models import Consultant
-from apps.users.constants import COUNTERSTAFF_GROUP_NAME
+from apps.users.constants import UserRole as Roles
+from apps.users.permissions import role_required
 
 
-@login_required
+@role_required(Roles.STAFF)
 def vetting_dashboard(request):
     """Display consultant applications for vetting staff to review."""
-
-    if not request.user.groups.filter(name=COUNTERSTAFF_GROUP_NAME).exists():
-        return HttpResponseForbidden()
 
     consultants = Consultant.objects.all().order_by("full_name")
 


### PR DESCRIPTION
## Summary
- gate consultant application and certificate dashboards behind the consultant role decorator
- require the staff role for vetting, reuse the shared role helper for reviewer access, and seed reviewer groups from the new mapping
- route authenticated users to the appropriate dashboards via the shared helper and extend the test suites to cover 403 responses for unauthorised roles

## Testing
- python manage.py test apps.consultants apps.certificates apps.vetting apps.decisions apps.users


------
https://chatgpt.com/codex/tasks/task_e_68dd70e349c08326975e1f9310f1ce96