### PR TITLE
Assign consultant group to new registrations

### DIFF
--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -20,6 +20,33 @@ from apps.users.constants import (
 from apps.users.permissions import role_required, user_has_role
 
 
+class RegistrationTests(TestCase):
+    def setUp(self):
+        Group.objects.get_or_create(name=CONSULTANTS_GROUP_NAME)
+
+    def test_register_assigns_consultant_group(self):
+        response = self.client.post(
+            reverse("register"),
+            {
+                "username": "newconsultant",
+                "password1": "complex-password-123",
+                "password2": "complex-password-123",
+            },
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("login"),
+            fetch_redirect_response=False,
+        )
+
+        user = get_user_model().objects.get(username="newconsultant")
+        self.assertTrue(
+            user.groups.filter(name=CONSULTANTS_GROUP_NAME).exists(),
+            "Newly registered users should be assigned to the consultants group.",
+        )
+
+
 class SeedUsersCommandTests(TestCase):
     def test_seeded_reviewer_matches_access_control(self):
         """Ensure the seed command populates reviewer groups correctly."""

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,17 +1,22 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import Group
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 
 from apps.consultants.models import Consultant
-from apps.users.constants import UserRole as Roles
+from apps.users.constants import CONSULTANTS_GROUP_NAME, UserRole as Roles
 from apps.users.permissions import user_has_role
 
 def register(request):
     if request.method == 'POST':
         form = UserCreationForm(request.POST)
         if form.is_valid():
-            form.save()
+            user = form.save()
+            consultant_group, _ = Group.objects.get_or_create(
+                name=CONSULTANTS_GROUP_NAME
+            )
+            user.groups.add(consultant_group)
             return redirect('login')
     else:
         form = UserCreationForm()


### PR DESCRIPTION
## Summary
- ensure newly created accounts are placed into the Consultants group so they can access the applicant dashboard
- add a regression test covering group assignment during registration

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68dd888a34cc8326adf0d36bdaf34f55