### PR TITLE
Add vetting action test for dashboard view

### DIFF
--- a/apps/vetting/tests.py
+++ b/apps/vetting/tests.py
@@ -84,3 +84,13 @@ class VettingDashboardViewTests(TestCase):
         )
         self.consultant.refresh_from_db()
         self.assertEqual(self.consultant.status, 'rejected')
+
+    def test_can_vet_consultant(self):
+        response = self.client.post(
+            reverse('vetting_dashboard'),
+            data={'consultant_id': self.consultant.id, 'action': 'vet'},
+        )
+
+        self.consultant.refresh_from_db()
+        self.assertEqual(self.consultant.status, 'vetted')
+        self.assertRedirects(response, reverse('vetting_dashboard'))


### PR DESCRIPTION
## Summary
- add a test ensuring the vetting dashboard view updates consultants to vetted when posted with the vet action
- verify the view redirects back to the dashboard after vetting

## Testing
- python manage.py test apps.vetting

------
https://chatgpt.com/codex/tasks/task_e_68dd8d9cac548326aa4d9f83a7b74769