### PR TITLE
Align BASE_DIR with project root

### DIFF
--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -12,7 +12,7 @@ from django.urls import reverse_lazy
 import dj_database_url
 
 
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 
 def get_env_bool(name: str, default: bool = False) -> bool:


### PR DESCRIPTION
## Summary
- update `BASE_DIR` to point to the project root so shared paths resolve from a single source
- verified the templates directory resolves correctly with the new base path

## Testing
- `python manage.py shell -c "from django.conf import settings; print(settings.BASE_DIR); print(settings.TEMPLATES[0]['DIRS'])"`
- `python manage.py shell -c "from django.template.loader import get_template; from django.contrib.auth.models import AnonymousUser; tpl = get_template('staff_dashboard.html'); rendered = tpl.render({'user': AnonymousUser()}); print('Rendered length:', len(rendered))"`


------
https://chatgpt.com/codex/tasks/task_e_68deb90dccac83268025654f1c4d9cec