### PR TITLE
Align production static asset settings with development

### DIFF
--- a/backend/settings/prod.py
+++ b/backend/settings/prod.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from django.conf import global_settings
+
 from .base import *  # noqa: F401,F403
 from .base import (
     BASE_DIR,
@@ -18,5 +20,11 @@ SECRET_KEY = get_secret_key(DEBUG)
 ALLOWED_HOSTS = build_allowed_hosts(["localhost", "127.0.0.1", "0.0.0.0"])
 CSRF_TRUSTED_ORIGINS = build_csrf_trusted_origins(ALLOWED_HOSTS)
 
-STATICFILES_DIRS = []
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STATICFILES_DIRS = [BASE_DIR / "static"]
+
+STORAGES = {
+    **getattr(global_settings, "STORAGES", {}),
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}


### PR DESCRIPTION
## Summary
- load the shared `static/` directory in production so it uses the same assets as development
- configure Django 5 storages so production serves static files through WhiteNoise's compressed manifest backend

## Testing
- python manage.py collectstatic --settings=backend.settings.prod --noinput
- python manage.py runserver --settings=backend.settings.prod 0.0.0.0:8000
- curl -s http://127.0.0.1:8000/static/css/style.css | head

------
https://chatgpt.com/codex/tasks/task_e_68deba00fd488326b98141d1be90832c