### PR TITLE
Add pre-commit hooks for formatting and linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        additional_dependencies: []

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+## Development setup
+
+We use [`pre-commit`](https://pre-commit.com/) to run formatting and linting before each commit.
+
+1. Install the tooling:
+   ```bash
+   pip install pre-commit
+   ```
+2. Install the hooks for this repository:
+   ```bash
+   pre-commit install
+   ```
+3. (Optional) Run the hooks against all files to verify the workspace:
+   ```bash
+   pre-commit run --all-files
+   ```
+
+The configured hooks cover Black, isort, Flake8, and basic whitespace checks to keep the codebase consistent.


### PR DESCRIPTION
## Summary
- add a pre-commit configuration that runs formatting, linting, and whitespace checks
- document how to install and use the hooks for contributors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dec346c5888326aae6d32d420e3692