### PR TITLE
Refactor decision handling to use service and tasks

### DIFF
--- a/apps/decisions/services.py
+++ b/apps/decisions/services.py
@@ -1,0 +1,105 @@
+"""Service layer helpers for decision handling."""
+from __future__ import annotations
+
+from typing import Optional, TYPE_CHECKING
+
+from django.db import transaction
+
+from apps.consultants.models import Consultant
+
+from .models import ApplicationAction
+from .tasks import (
+    generate_approval_certificate_task,
+    generate_rejection_letter_task,
+    send_decision_email_task,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checkers only
+    from django.contrib.auth.models import AbstractBaseUser as User
+else:  # pragma: no cover - runtime typing fallback
+    from typing import Any as User
+
+
+def _actor_display_name(actor: User) -> Optional[str]:
+    full_name = actor.get_full_name()
+    return full_name or getattr(actor, "username", None)
+
+
+def process_decision_action(
+    consultant: Consultant,
+    action: str,
+    actor: User,
+    *,
+    notes: str = "",
+) -> ApplicationAction:
+    """Persist the action, update the consultant, and queue side-effects."""
+
+    generated_by = _actor_display_name(actor)
+
+    with transaction.atomic():
+        action_obj = ApplicationAction.objects.create(
+            consultant=consultant,
+            actor=actor,
+            action=action,
+            notes=notes,
+        )
+
+        update_fields = ["status"]
+        new_status = consultant.status
+
+        if action == "vetted":
+            new_status = "vetted"
+        elif action == "approved":
+            new_status = "approved"
+            if consultant.certificate_pdf:
+                consultant.certificate_pdf.delete(save=False)
+            consultant.certificate_pdf = None
+            consultant.certificate_generated_at = None
+            if consultant.rejection_letter:
+                consultant.rejection_letter.delete(save=False)
+            consultant.rejection_letter = None
+            consultant.rejection_letter_generated_at = None
+            update_fields.extend(
+                [
+                    "certificate_pdf",
+                    "certificate_generated_at",
+                    "rejection_letter",
+                    "rejection_letter_generated_at",
+                ]
+            )
+        elif action == "rejected":
+            new_status = "rejected"
+            if consultant.rejection_letter:
+                consultant.rejection_letter.delete(save=False)
+            consultant.rejection_letter = None
+            consultant.rejection_letter_generated_at = None
+            if consultant.certificate_pdf:
+                consultant.certificate_pdf.delete(save=False)
+            consultant.certificate_pdf = None
+            consultant.certificate_generated_at = None
+            update_fields.extend(
+                [
+                    "rejection_letter",
+                    "rejection_letter_generated_at",
+                    "certificate_pdf",
+                    "certificate_generated_at",
+                ]
+            )
+
+        consultant.status = new_status
+        consultant.save(update_fields=update_fields)
+
+        def queue_tasks():
+            if action == "approved":
+                generate_approval_certificate_task.delay(consultant.pk, generated_by)
+                send_decision_email_task.delay(consultant.pk, action)
+            elif action == "rejected":
+                generate_rejection_letter_task.delay(consultant.pk, generated_by)
+                send_decision_email_task.delay(consultant.pk, action)
+            elif action == "vetted":
+                # No side-effects besides the status change.
+                pass
+
+        transaction.on_commit(queue_tasks)
+
+    return action_obj

--- a/apps/decisions/tasks.py
+++ b/apps/decisions/tasks.py
@@ -1,0 +1,44 @@
+"""Background tasks for decision side effects."""
+from __future__ import annotations
+
+from typing import Callable
+
+from apps.certificates.services import (
+    generate_approval_certificate,
+    generate_rejection_letter,
+)
+from apps.consultants.models import Consultant
+from .emails import send_decision_email
+
+try:  # pragma: no cover - exercised implicitly when Celery is installed
+    from celery import shared_task
+except ModuleNotFoundError:  # pragma: no cover - provides a fallback in tests
+    def shared_task(*dargs, **dkwargs):
+        def decorator(func: Callable):
+            def delay(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            func.delay = delay  # type: ignore[attr-defined]
+            return func
+
+        if dargs and callable(dargs[0]) and not dkwargs:
+            return decorator(dargs[0])
+        return decorator
+
+
+@shared_task(name="decisions.generate_approval_certificate")
+def generate_approval_certificate_task(consultant_id: int, generated_by: str | None = None):
+    consultant = Consultant.objects.get(pk=consultant_id)
+    generate_approval_certificate(consultant, generated_by=generated_by)
+
+
+@shared_task(name="decisions.generate_rejection_letter")
+def generate_rejection_letter_task(consultant_id: int, generated_by: str | None = None):
+    consultant = Consultant.objects.get(pk=consultant_id)
+    generate_rejection_letter(consultant, generated_by=generated_by)
+
+
+@shared_task(name="decisions.send_decision_email")
+def send_decision_email_task(consultant_id: int, action: str):
+    consultant = Consultant.objects.get(pk=consultant_id)
+    send_decision_email(consultant, action)

--- a/apps/decisions/tests/test_services.py
+++ b/apps/decisions/tests/test_services.py
@@ -1,0 +1,94 @@
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.consultants.models import Consultant
+from apps.decisions.models import ApplicationAction
+from apps.decisions.services import process_decision_action
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def consultant(db):
+    user_model = get_user_model()
+    user = user_model.objects.create_user(
+        username="applicant",
+        email="applicant@example.com",
+        password="password123",
+    )
+    return Consultant.objects.create(
+        user=user,
+        full_name="Applicant One",
+        id_number="ID123",
+        dob="1990-01-01",
+        gender="M",
+        nationality="Country",
+        email=user.email,
+        phone_number="555-0000",
+        business_name="Biz",
+    )
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def actor(db):
+    user_model = get_user_model()
+    return user_model.objects.create_user(
+        username="reviewer",
+        email="reviewer@example.com",
+        password="password123",
+        first_name="Review",
+        last_name="Er",
+    )
+
+
+@pytest.mark.django_db
+def test_process_decision_action_queues_approval_tasks(mocker, consultant, actor):
+    generate_task = mocker.patch(
+        "apps.decisions.services.generate_approval_certificate_task.delay"
+    )
+    email_task = mocker.patch("apps.decisions.services.send_decision_email_task.delay")
+
+    action = process_decision_action(consultant, "approved", actor, notes="All good")
+
+    consultant.refresh_from_db()
+
+    assert consultant.status == "approved"
+    assert ApplicationAction.objects.filter(pk=action.pk, action="approved").exists()
+    generate_task.assert_called_once_with(consultant.pk, "Review Er")
+    email_task.assert_called_once_with(consultant.pk, "approved")
+
+
+@pytest.mark.django_db
+def test_process_decision_action_queues_rejection_tasks(mocker, consultant, actor):
+    generate_task = mocker.patch(
+        "apps.decisions.services.generate_rejection_letter_task.delay"
+    )
+    email_task = mocker.patch("apps.decisions.services.send_decision_email_task.delay")
+
+    process_decision_action(consultant, "rejected", actor)
+
+    consultant.refresh_from_db()
+
+    assert consultant.status == "rejected"
+    generate_task.assert_called_once_with(consultant.pk, "Review Er")
+    email_task.assert_called_once_with(consultant.pk, "rejected")
+
+
+@pytest.mark.django_db
+def test_process_decision_action_for_vetted_has_no_tasks(mocker, consultant, actor):
+    send_email = mocker.patch("apps.decisions.services.send_decision_email_task.delay")
+    approval_task = mocker.patch(
+        "apps.decisions.services.generate_approval_certificate_task.delay"
+    )
+    rejection_task = mocker.patch(
+        "apps.decisions.services.generate_rejection_letter_task.delay"
+    )
+
+    process_decision_action(consultant, "vetted", actor)
+
+    consultant.refresh_from_db()
+    assert consultant.status == "vetted"
+    send_email.assert_not_called()
+    approval_task.assert_not_called()
+    rejection_task.assert_not_called()
+    assert ApplicationAction.objects.filter(action="vetted").exists()

--- a/apps/decisions/tests/test_views.py
+++ b/apps/decisions/tests/test_views.py
@@ -1,0 +1,92 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.urls import reverse
+
+from apps.consultants.models import Consultant
+from apps.users.constants import BOARD_COMMITTEE_GROUP_NAME
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def reviewer_user(db):
+    user_model = get_user_model()
+    user = user_model.objects.create_user(
+        username="board_member",
+        email="board@example.com",
+        password="password123",
+        first_name="Board",
+        last_name="Member",
+    )
+    group, _ = Group.objects.get_or_create(name=BOARD_COMMITTEE_GROUP_NAME)
+    user.groups.add(group)
+    return user
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def consultant(db, reviewer_user):
+    applicant_model = get_user_model()
+    applicant = applicant_model.objects.create_user(
+        username="applicant_view",
+        email="applicant_view@example.com",
+        password="password123",
+    )
+    return Consultant.objects.create(
+        user=applicant,
+        full_name="Applicant View",
+        id_number="ID999",
+        dob="1990-01-01",
+        gender="M",
+        nationality="Country",
+        email=applicant.email,
+        phone_number="555-0100",
+        business_name="BizView",
+        status="vetted",
+    )
+
+
+@pytest.mark.django_db
+def test_decisions_dashboard_uses_service(client, mocker, reviewer_user, consultant):
+    service = mocker.patch("apps.decisions.views.process_decision_action")
+    client.force_login(reviewer_user)
+
+    response = client.post(
+        reverse("decisions_dashboard"),
+        {
+            "consultant_id": str(consultant.pk),
+            "action": "approved",
+            "notes": "Looks good",
+        },
+        follow=False,
+    )
+
+    assert response.status_code == 302
+    service.assert_called_once()
+    called_consultant, called_action, called_user = service.call_args[0]
+    assert called_consultant == consultant
+    assert called_action == "approved"
+    assert called_user == reviewer_user
+    assert service.call_args.kwargs.get("notes") == "Looks good"
+
+
+@pytest.mark.django_db
+def test_application_detail_uses_service(client, mocker, reviewer_user, consultant):
+    service = mocker.patch("apps.decisions.views.process_decision_action")
+    client.force_login(reviewer_user)
+
+    response = client.post(
+        reverse("officer_application_detail", args=[consultant.pk]),
+        {
+            "action": "rejected",
+            "notes": "Needs more documents",
+        },
+    )
+
+    assert response.status_code == 302
+    service.assert_called_once()
+    called_consultant, called_action, called_user = service.call_args[0]
+    assert called_consultant == consultant
+    assert called_action == "rejected"
+    assert called_user == reviewer_user
+    assert service.call_args.kwargs.get("notes") == "Needs more documents"


### PR DESCRIPTION
## Summary
- add a decision-processing service that updates consultant state and enqueues side effects
- introduce Celery-compatible tasks for document generation and email notifications
- refactor decision views to call the service and add tests covering the orchestration and task dispatch

## Testing
- pytest apps/decisions/tests -q *(fails: Django package not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ded773df8883269774b521087cb2cb