### PR TITLE
Add fail-fast behaviour to build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # Install dependencies
 pip install -r requirements.txt
 


### PR DESCRIPTION
## Summary
- ensure the build script exits on the first failure by enabling fail-fast shell options

## Testing
- PATH="$(pwd)/fakebin:$PATH" bash build.sh *(with temporary shims to force collectstatic to fail and confirm a non-zero exit)*

------
https://chatgpt.com/codex/tasks/task_e_68dede5c5364832694cdf243fe82cf43