### PR TITLE
Configure Sentry monitoring for production

### DIFF
--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock, patch
 
 from django.contrib.auth import get_user_model
@@ -5,7 +6,7 @@ from django.contrib.auth.models import Group
 from django.core.management import call_command
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.urls import reverse
 
 from apps.decisions.views import is_reviewer
@@ -20,6 +21,7 @@ from apps.users.constants import (
     UserRole,
 )
 from apps.users.permissions import role_required, user_has_role
+from backend.settings import base as settings_base
 from apps.users.management.commands.seed_test_users import GROUPS as TEST_USER_GROUPS, PASSWORD as TEST_USER_PASSWORD
 
 
@@ -199,3 +201,11 @@ class RolePermissionTests(TestCase):
 
         with self.assertRaises(PermissionDenied):
             sample_view(request)
+
+
+class MonitoringInitTests(SimpleTestCase):
+    def test_init_sentry_no_dsn_returns_none(self):
+        """Sentry initialisation should be a no-op when no DSN is configured."""
+
+        with patch.dict(os.environ, {"SENTRY_DSN": ""}, clear=False):
+            self.assertIsNone(settings_base.init_sentry())

--- a/render.yaml
+++ b/render.yaml
@@ -16,6 +16,12 @@ services:
         fromDatabase:
           name: consultant-db
           property: connectionString
+      - key: SENTRY_DSN
+        value: ""
+      - key: SENTRY_TRACES_SAMPLE_RATE
+        value: "0.2"
+      - key: SENTRY_PROFILES_SAMPLE_RATE
+        value: "0.0"
 
 databases:
   - name: consultant-db

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,4 @@ pillow==11.3.0
 psycopg2-binary==2.9.10
 sqlparse==0.5.3
 whitenoise==6.11.0
-
-
-whitenoise==6.6.0
+sentry-sdk[django]==1.45.0


### PR DESCRIPTION
## Summary
- add sentry-sdk with Django integration to the Python dependencies and configure initialization in the shared settings module
- expose Sentry DSN and sampling options in Render deployment environment variables
- add a smoke test ensuring Sentry initialization is a no-op when no DSN is provided

## Testing
- `python manage.py test apps.users.tests.MonitoringInitTests`


------
https://chatgpt.com/codex/tasks/task_e_68dee4e083ac8326a0a08b741cbac4b8