### PR TITLE
Add health check endpoint for monitoring

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,5 @@
+# Deployment & Monitoring Notes
+
+- The application exposes a lightweight health endpoint at `/health/` that returns a JSON payload containing the service status and database connectivity indicator.
+- Configure your hosting platform or uptime monitoring tool to poll this endpoint for availability checks.
+- Because the endpoint avoids opening new database connections, it remains responsive even when the database is under load or temporarily unavailable.

--- a/apps/users/tests/test_health.py
+++ b/apps/users/tests/test_health.py
@@ -1,0 +1,10 @@
+from django.urls import reverse
+
+
+def test_health_endpoint_returns_ok(client):
+    response = client.get(reverse("health"))
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert "database" in payload

--- a/backend/health.py
+++ b/backend/health.py
@@ -1,0 +1,28 @@
+"""Simple health check view for uptime monitoring."""
+from __future__ import annotations
+
+from django.db import connections
+from django.db.utils import OperationalError
+from django.http import JsonResponse
+
+
+def health_view(request):
+    """Return a lightweight service health response."""
+    payload = {"status": "ok"}
+
+    connection = connections["default"]
+    db_status = "unknown"
+
+    try:
+        if connection.connection is not None and connection.is_usable():
+            db_status = "ok"
+        elif connection.connection is None:
+            # Avoid opening new connections to keep the check fast.
+            db_status = "unverified"
+        else:
+            db_status = "unavailable"
+    except OperationalError:
+        db_status = "unavailable"
+
+    payload["database"] = db_status
+    return JsonResponse(payload)

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -14,13 +14,16 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
-from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
+from django.contrib import admin
+from django.urls import include, path
+
+from .health import health_view
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('health/', health_view, name='health'),
     path('', include('apps.users.urls')),
     path('consultants/', include('apps.consultants.urls')),
     path('certificates/', include(('apps.certificates.urls', 'certificates'), namespace='certificates')),


### PR DESCRIPTION
## Summary
- add a lightweight health view that returns an "ok" payload and avoids slow database probes
- expose the health endpoint via the project URL configuration and document it for deployment monitoring
- add a regression test that exercises the new health endpoint response

## Testing
- pytest apps/users/tests/test_health.py *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68dee6f4c3048326ab0b58c9328f5fc0