### PR TITLE
Ensure decision emails follow document generation

### DIFF
--- a/apps/decisions/services.py
+++ b/apps/decisions/services.py
@@ -11,7 +11,6 @@ from .models import ApplicationAction
 from .tasks import (
     generate_approval_certificate_task,
     generate_rejection_letter_task,
-    send_decision_email_task,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - used for type checkers only
@@ -92,10 +91,8 @@ def process_decision_action(
         def queue_tasks():
             if action == "approved":
                 generate_approval_certificate_task.delay(consultant.pk, generated_by)
-                send_decision_email_task.delay(consultant.pk, action)
             elif action == "rejected":
                 generate_rejection_letter_task.delay(consultant.pk, generated_by)
-                send_decision_email_task.delay(consultant.pk, action)
             elif action == "vetted":
                 # No side-effects besides the status change.
                 pass

--- a/apps/decisions/tasks.py
+++ b/apps/decisions/tasks.py
@@ -30,12 +30,14 @@ except ModuleNotFoundError:  # pragma: no cover - provides a fallback in tests
 def generate_approval_certificate_task(consultant_id: int, generated_by: str | None = None):
     consultant = Consultant.objects.get(pk=consultant_id)
     generate_approval_certificate(consultant, generated_by=generated_by)
+    send_decision_email_task.delay(consultant_id, "approved")
 
 
 @shared_task(name="decisions.generate_rejection_letter")
 def generate_rejection_letter_task(consultant_id: int, generated_by: str | None = None):
     consultant = Consultant.objects.get(pk=consultant_id)
     generate_rejection_letter(consultant, generated_by=generated_by)
+    send_decision_email_task.delay(consultant_id, "rejected")
 
 
 @shared_task(name="decisions.send_decision_email")

--- a/apps/decisions/tests/test_services.py
+++ b/apps/decisions/tests/test_services.py
@@ -46,7 +46,7 @@ def test_process_decision_action_queues_approval_tasks(mocker, consultant, actor
     generate_task = mocker.patch(
         "apps.decisions.services.generate_approval_certificate_task.delay"
     )
-    email_task = mocker.patch("apps.decisions.services.send_decision_email_task.delay")
+    email_task = mocker.patch("apps.decisions.tasks.send_decision_email_task.delay")
 
     action = process_decision_action(consultant, "approved", actor, notes="All good")
 
@@ -55,7 +55,7 @@ def test_process_decision_action_queues_approval_tasks(mocker, consultant, actor
     assert consultant.status == "approved"
     assert ApplicationAction.objects.filter(pk=action.pk, action="approved").exists()
     generate_task.assert_called_once_with(consultant.pk, "Review Er")
-    email_task.assert_called_once_with(consultant.pk, "approved")
+    email_task.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -63,7 +63,7 @@ def test_process_decision_action_queues_rejection_tasks(mocker, consultant, acto
     generate_task = mocker.patch(
         "apps.decisions.services.generate_rejection_letter_task.delay"
     )
-    email_task = mocker.patch("apps.decisions.services.send_decision_email_task.delay")
+    email_task = mocker.patch("apps.decisions.tasks.send_decision_email_task.delay")
 
     process_decision_action(consultant, "rejected", actor)
 
@@ -71,12 +71,12 @@ def test_process_decision_action_queues_rejection_tasks(mocker, consultant, acto
 
     assert consultant.status == "rejected"
     generate_task.assert_called_once_with(consultant.pk, "Review Er")
-    email_task.assert_called_once_with(consultant.pk, "rejected")
+    email_task.assert_not_called()
 
 
 @pytest.mark.django_db
 def test_process_decision_action_for_vetted_has_no_tasks(mocker, consultant, actor):
-    send_email = mocker.patch("apps.decisions.services.send_decision_email_task.delay")
+    send_email = mocker.patch("apps.decisions.tasks.send_decision_email_task.delay")
     approval_task = mocker.patch(
         "apps.decisions.services.generate_approval_certificate_task.delay"
     )

--- a/apps/decisions/tests/test_tasks.py
+++ b/apps/decisions/tests/test_tasks.py
@@ -1,0 +1,72 @@
+import pytest
+
+from django.contrib.auth import get_user_model
+
+from apps.consultants.models import Consultant
+
+from apps.decisions.tasks import (
+    generate_approval_certificate_task,
+    generate_rejection_letter_task,
+)
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def consultant(db):
+    user_model = get_user_model()
+    user = user_model.objects.create_user(
+        username="task-applicant",
+        email="task-applicant@example.com",
+        password="password123",
+    )
+    return Consultant.objects.create(
+        user=user,
+        full_name="Task Applicant",
+        id_number="ID999",
+        dob="1990-01-01",
+        gender="F",
+        nationality="Country",
+        email=user.email,
+        phone_number="555-1111",
+        business_name="Task Biz",
+    )
+
+
+@pytest.mark.django_db
+def test_generate_approval_certificate_task_dispatches_email_after_document(
+    mocker, consultant
+):
+    send_email = mocker.patch("apps.decisions.tasks.send_decision_email_task.delay")
+
+    def ensure_email_not_yet_called(*args, **kwargs):
+        assert not send_email.called
+
+    generate = mocker.patch(
+        "apps.decisions.tasks.generate_approval_certificate",
+        side_effect=ensure_email_not_yet_called,
+    )
+
+    generate_approval_certificate_task(consultant.pk, generated_by="Reviewer")
+
+    generate.assert_called_once_with(consultant, generated_by="Reviewer")
+    send_email.assert_called_once_with(consultant.pk, "approved")
+
+
+@pytest.mark.django_db
+def test_generate_rejection_letter_task_dispatches_email_after_document(
+    mocker, consultant
+):
+    send_email = mocker.patch("apps.decisions.tasks.send_decision_email_task.delay")
+
+    def ensure_email_not_yet_called(*args, **kwargs):
+        assert not send_email.called
+
+    generate = mocker.patch(
+        "apps.decisions.tasks.generate_rejection_letter",
+        side_effect=ensure_email_not_yet_called,
+    )
+
+    generate_rejection_letter_task(consultant.pk, generated_by="Reviewer")
+
+    generate.assert_called_once_with(consultant, generated_by="Reviewer")
+    send_email.assert_called_once_with(consultant.pk, "rejected")


### PR DESCRIPTION
## Summary
- queue only the document-generation task from `process_decision_action`
- trigger decision emails after documents finish generating within the Celery tasks
- extend service and task tests to assert email dispatch occurs after document creation

## Testing
- pytest apps/decisions/tests -q *(fails: Django settings/configuration missing in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfa7d14e8483269da7bbe094cee714