### PR TITLE
Validate retained consultant documents

### DIFF
--- a/apps/consultants/forms.py
+++ b/apps/consultants/forms.py
@@ -1,5 +1,8 @@
+import mimetypes
+
 from django import forms
 from django.core.files.uploadedfile import UploadedFile
+from django.db.models.fields.files import FieldFile
 
 from .models import Consultant
 
@@ -24,20 +27,40 @@ class ConsultantForm(forms.ModelForm):
             for field in self.DOCUMENT_FIELDS:
                 file = cleaned_data.get(field)
 
-                if isinstance(file, UploadedFile):
-                    if file.size > self.MAX_FILE_SIZE:
-                        self.add_error(field, "File size must be under 2MB.")
-                    if file.content_type not in self.ALLOWED_CONTENT_TYPES:
-                        self.add_error(field, "Only PDF, JPG, or PNG files are allowed.")
-                elif file:
-                    # Existing file retained, nothing to validate.
+                if file is False:
+                    cleaned_data[field] = None
+                    self.add_error(field, "This document is required.")
                     continue
+
+                if isinstance(file, (UploadedFile, FieldFile)):
+                    self._validate_file(field, file)
                 else:
                     existing_file = getattr(self.instance, field, None)
-                    if not existing_file:
+                    if existing_file:
+                        self._validate_file(field, existing_file)
+                    else:
                         self.add_error(field, "This document is required.")
 
         return cleaned_data
+
+    def _validate_file(self, field, file_obj):
+        try:
+            size = file_obj.size
+        except Exception:  # pragma: no cover - defensive, should not occur in tests
+            size = None
+
+        if size and size > self.MAX_FILE_SIZE:
+            self.add_error(field, "File size must be under 2MB.")
+
+        content_type = getattr(file_obj, 'content_type', None)
+        if not content_type and hasattr(file_obj, 'file'):
+            content_type = getattr(file_obj.file, 'content_type', None)
+        if not content_type and hasattr(file_obj, 'name'):
+            guessed_type, _ = mimetypes.guess_type(file_obj.name)
+            content_type = guessed_type
+
+        if content_type and content_type not in self.ALLOWED_CONTENT_TYPES:
+            self.add_error(field, "Only PDF, JPG, or PNG files are allowed.")
 
     class Meta:
         model = Consultant


### PR DESCRIPTION
## Summary
- re-run file validation for retained consultant documents and detect cleared uploads during submission
- add helper to validate stored file size and content type, including guessed MIME types
- expand ConsultantFormTests to cover retained invalid files and cleared document scenarios

## Testing
- python manage.py test apps.consultants.tests.ConsultantFormTests

------
https://chatgpt.com/codex/tasks/task_e_68dfb2b2aa6883269c12f25002ab5857