### PR TITLE
Normalize template inheritance to base layout

### DIFF
--- a/templates/certificates/dashboard.html
+++ b/templates/certificates/dashboard.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 
 {% block title %}Decision documents{% endblock %}
 

--- a/templates/consultants/application_form.html
+++ b/templates/consultants/application_form.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 
 {% block title %}{{ is_editing|yesno:"Edit,Submit" }} Consultant Application{% endblock %}
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 
 {% block title %}Dashboard{% endblock %}
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 
 {% block title %}Home{% endblock %}
 

--- a/templates/officer/application_detail.html
+++ b/templates/officer/application_detail.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 
 {% block title %}Application Detail – Staff{% endblock %}
 

--- a/templates/officer/applications_list.html
+++ b/templates/officer/applications_list.html
@@ -1,43 +1,57 @@
-<!DOCTYPE html>
-<html>
-<head><title>Applications – Staff</title></head>
-<body>
-  <h2>Applications (Staff)</h2>
+{% extends "base.html" %}
 
-  <p>Filter:
-    <a href="?">Submitted+Vetted (default)</a> |
-    <a href="?status=draft">Draft</a> |
-    <a href="?status=submitted">Submitted</a> |
-    <a href="?status=vetted">Vetted</a> |
-    <a href="?status=approved">Approved</a> |
-    <a href="?status=rejected">Rejected</a>
-  </p>
+{% block title %}Applications – Staff{% endblock %}
 
-  <table border="1" cellpadding="6" cellspacing="0">
-    <thead>
-      <tr>
-        <th>Full Name</th>
-        <th>Business</th>
-        <th>Status</th>
-        <th>Submitted</th>
-        <th>View</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for app in applications %}
-      <tr>
-        <td>{{ app.full_name }}</td>
-        <td>{{ app.business_name }}</td>
-        <td>{{ app.status|title }}</td>
-        <td>{{ app.submitted_at }}</td>
-        <td><a href="{% url 'officer_application_detail' app.pk %}">Open</a></td>
-      </tr>
-      {% empty %}
-      <tr><td colspan="5">No applications found.</td></tr>
-      {% endfor %}
-    </tbody>
-  </table>
+{% block content %}
+<div class="page-stack">
+  <section class="data-card">
+    <div class="card-header">
+      <h2>Applications (Staff)</h2>
+      <p class="card-subtitle">Filter applications by their current status to find the records you need.</p>
+    </div>
+    <nav class="filter-nav">
+      <ul>
+        <li><a href="?">Submitted + Vetted (default)</a></li>
+        <li><a href="?status=draft">Draft</a></li>
+        <li><a href="?status=submitted">Submitted</a></li>
+        <li><a href="?status=vetted">Vetted</a></li>
+        <li><a href="?status=approved">Approved</a></li>
+        <li><a href="?status=rejected">Rejected</a></li>
+      </ul>
+    </nav>
 
-  <p><a href="{% url 'dashboard' %}">Back to Dashboard</a></p>
-</body>
-</html>
+    <div class="table-wrapper">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th scope="col">Full Name</th>
+            <th scope="col">Business</th>
+            <th scope="col">Status</th>
+            <th scope="col">Submitted</th>
+            <th scope="col">View</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for app in applications %}
+          <tr>
+            <td>{{ app.full_name }}</td>
+            <td>{{ app.business_name }}</td>
+            <td>{{ app.status|title }}</td>
+            <td>{{ app.submitted_at|default:"—" }}</td>
+            <td><a class="btn-link" href="{% url 'officer_application_detail' app.pk %}">Open</a></td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="5" class="muted">No applications found.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <div class="back-link">
+    <a href="{% url 'dashboard' %}">← Back to dashboard</a>
+  </div>
+</div>
+{% endblock %}

--- a/templates/officer/decisions_dashboard.html
+++ b/templates/officer/decisions_dashboard.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 
 {% block title %}Decisions dashboard{% endblock %}
 

--- a/templates/officer/renewal_requests.html
+++ b/templates/officer/renewal_requests.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 
 {% block title %}Certificate Renewal Requests{% endblock %}
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 
 {% block title %}Create an Account{% endblock %}
 

--- a/templates/registration/login.html
+++ b/templates/registration/login.html
@@ -1,4 +1,4 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 
 {% block title %}Sign in{% endblock %}
 

--- a/templates/registration/logout.html
+++ b/templates/registration/logout.html
@@ -1,8 +1,13 @@
-<!DOCTYPE html>
-<html>
-<head><title>Logged out</title></head>
-<body>
-  <p>You have been logged out.</p>
-  <a href="{% url 'login' %}">Login again</a>
-</body>
-</html>
+{% extends "base.html" %}
+
+{% block title %}Signed out{% endblock %}
+
+{% block content %}
+<section class="form-card">
+  <h1>Signed out</h1>
+  <p class="description">You have been logged out successfully.</p>
+  <div class="form-actions">
+    <a class="btn-primary" href="{% url 'login' %}">Sign in again</a>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- ensure templates extend the shared base layout with consistent syntax
- refactor staff applications list and logout pages to render within the base blocks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3c499d7948326bbc3b76c085fc4dc