### PR TITLE
Enforce POST-only logout view

### DIFF
--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -122,6 +122,12 @@ class LogoutRedirectTests(TestCase):
             fetch_redirect_response=False,
         )
 
+    def test_logout_rejects_get_requests(self):
+        """Logging out should require a POST to prevent CSRF-able GETs."""
+
+        response = self.client.get(reverse("logout"))
+        self.assertEqual(response.status_code, 405)
+
 
 class RolePermissionTests(TestCase):
     def setUp(self):

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -5,7 +5,7 @@ from .views import home_view
 
 urlpatterns = [
     path('login/', auth_views.LoginView.as_view(template_name='registration/login.html'), name='login'),
-    path('logout/', auth_views.LogoutView.as_view(), name='logout'),
+    path('logout/', views.logout_view, name='logout'),
     path('register/', views.register, name='register'),
     path('dashboard/', views.dashboard, name='dashboard'),
     path('', home_view, name='home'),

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,8 +1,10 @@
 from django.shortcuts import render, redirect
+from django.contrib.auth import logout
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import Group
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
+from django.views.decorators.http import require_POST
 
 from apps.consultants.models import Consultant
 from apps.users.constants import CONSULTANTS_GROUP_NAME, UserRole as Roles
@@ -21,6 +23,15 @@ def register(request):
     else:
         form = UserCreationForm()
     return render(request, 'register.html', {'form': form})
+
+
+@require_POST
+def logout_view(request):
+    """Log out the current user via an explicit POST request."""
+
+    logout(request)
+    return redirect('login')
+
 
 @login_required
 def dashboard(request):


### PR DESCRIPTION
## Summary
- add a dedicated logout view that only accepts POST requests and redirects back to the sign-in page
- update the URL configuration to use the new view and keep the existing POST form workflow
- add a regression test to ensure GET requests are rejected with the expected 405 response

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c51a82d8832699fff416e89629f2