### PR TITLE
Restore database health check while keeping simple status endpoint

### DIFF
--- a/apps/users/tests/test_health.py
+++ b/apps/users/tests/test_health.py
@@ -1,4 +1,8 @@
+import json
+
 from django.urls import reverse
+
+from backend.health import database_health_view, health_view
 
 
 def test_health_endpoint_returns_ok(client):
@@ -6,5 +10,31 @@ def test_health_endpoint_returns_ok(client):
 
     assert response.status_code == 200
     payload = response.json()
+    assert payload == {"status": "ok"}
+
+
+def test_health_view_returns_simple_status(rf):
+    request = rf.get("/health/")
+    response = health_view(request)
+
+    assert response.status_code == 200
+    assert json.loads(response.content) == {"status": "ok"}
+
+
+def test_database_health_endpoint_includes_status(client):
+    response = client.get(reverse("health-database"))
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert "database" in payload
+
+
+def test_database_health_view_returns_status(rf):
+    request = rf.get("/health/database/")
+    response = database_health_view(request)
+
+    assert response.status_code == 200
+    payload = json.loads(response.content)
     assert payload["status"] == "ok"
     assert "database" in payload

--- a/backend/health.py
+++ b/backend/health.py
@@ -1,4 +1,4 @@
-"""Simple health check view for uptime monitoring."""
+"""Health check views for uptime monitoring."""
 from __future__ import annotations
 
 from django.db import connections
@@ -8,6 +8,11 @@ from django.http import JsonResponse
 
 def health_view(request):
     """Return a lightweight service health response."""
+    return JsonResponse({"status": "ok"})
+
+
+def database_health_view(request):
+    """Return health information that includes database connectivity."""
     payload = {"status": "ok"}
 
     connection = connections["default"]

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -19,11 +19,12 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 
-from .health import health_view
+from .health import database_health_view, health_view
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('health/', health_view, name='health'),
+    path('health/database/', database_health_view, name='health-database'),
     path('', include('apps.users.urls')),
     path('consultants/', include('apps.consultants.urls')),
     path('certificates/', include(('apps.certificates.urls', 'certificates'), namespace='certificates')),


### PR DESCRIPTION
## Summary
- reintroduce database-aware health check as a separate endpoint alongside the simple status response
- add URL routing and tests that cover both health endpoints

## Testing
- ⚠️ `pytest apps/users/tests/test_health.py` *(fails: duplicate section 'pytest' in pytest.ini)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cad6685083269a9915336dcc47ef