### PR TITLE
Align allowed hosts and CSRF defaults with environment variables

### DIFF
--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Iterable, Sequence
 
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
@@ -39,78 +38,14 @@ def get_secret_key(debug: bool) -> str:
         "DJANGO_SECRET_KEY must be set in production environments."
     )
 
-
-def _append_unique(items: list[str], value: str) -> None:
-    """Append a value to a list only if it does not already exist."""
-
-    if value and value not in items:
-        items.append(value)
-
-
-def _clean_hostname(hostname: str) -> str:
-    """Normalise hostnames by removing protocols and trailing slashes."""
-
-    cleaned = hostname.strip().removeprefix("https://").removeprefix("http://")
-    return cleaned.rstrip("/")
-
-
-def _get_render_hosts() -> list[str]:
-    """Collect Render deployment hostnames when available."""
-
-    render_host = os.getenv("RENDER_EXTERNAL_HOSTNAME")
-    if not render_host:
-        return []
-
-    cleaned_host = _clean_hostname(render_host)
-    if not cleaned_host:
-        return []
-
-    hosts = [cleaned_host]
-
-    bare_host = cleaned_host.split(":", maxsplit=1)[0]
-    if bare_host and bare_host != cleaned_host:
-        hosts.append(bare_host)
-
-    return hosts
-
-
-def build_allowed_hosts(default_hosts: Sequence[str] | None = None) -> list[str]:
-    """Build the ALLOWED_HOSTS list from the environment."""
-
-    hosts_env = os.getenv("DJANGO_ALLOWED_HOSTS")
-    if hosts_env:
-        hosts = [host.strip() for host in hosts_env.split(",") if host.strip()]
-    else:
-        hosts = list(default_hosts or [])
-
-    for render_host in _get_render_hosts():
-        _append_unique(hosts, render_host)
-
-    return hosts
-
-
-def build_csrf_trusted_origins(allowed_hosts: Iterable[str]) -> list[str]:
-    """Return CSRF trusted origins matching allowed hosts where possible."""
-
-    origins_env = os.getenv("DJANGO_CSRF_TRUSTED_ORIGINS")
-    if origins_env:
-        origins = [origin.strip() for origin in origins_env.split(",") if origin.strip()]
-    else:
-        origins = []
-
-    if not origins_env:
-        for host in allowed_hosts:
-            if host in {"localhost", "127.0.0.1"}:
-                continue
-            scheme = "https" if not host.startswith("http") else ""
-            origins.append(f"{scheme}://{host}" if scheme else host)
-
-    for render_host in _get_render_hosts():
-        scheme = "https" if not render_host.startswith("http") else ""
-        origin = f"{scheme}://{render_host}" if scheme else render_host
-        _append_unique(origins, origin)
-
-    return origins
+ALLOWED_HOSTS = os.getenv(
+    "ALLOWED_HOSTS",
+    "localhost,127.0.0.1,consultant-app-156x.onrender.com,.onrender.com",
+).split(",")
+CSRF_TRUSTED_ORIGINS = os.getenv(
+    "CSRF_TRUSTED_ORIGINS",
+    "https://consultant-app-156x.onrender.com,https://*.onrender.com",
+).split(",")
 
 
 def _get_sample_rate(name: str, default: float) -> float:

--- a/backend/settings/dev.py
+++ b/backend/settings/dev.py
@@ -3,19 +3,10 @@
 from __future__ import annotations
 
 from .base import *  # noqa: F401,F403
-from .base import (
-    BASE_DIR,
-    build_allowed_hosts,
-    build_csrf_trusted_origins,
-    get_env_bool,
-    get_secret_key,
-)
+from .base import BASE_DIR, get_env_bool, get_secret_key
 
 DEBUG = get_env_bool("DJANGO_DEBUG", default=True)
 
 SECRET_KEY = get_secret_key(DEBUG)
-
-ALLOWED_HOSTS = build_allowed_hosts(["localhost", "127.0.0.1", "0.0.0.0"])
-CSRF_TRUSTED_ORIGINS = build_csrf_trusted_origins(ALLOWED_HOSTS)
 
 STATICFILES_DIRS = [BASE_DIR / 'static']

--- a/backend/settings/prod.py
+++ b/backend/settings/prod.py
@@ -5,20 +5,11 @@ from __future__ import annotations
 from django.conf import global_settings
 
 from .base import *  # noqa: F401,F403
-from .base import (
-    BASE_DIR,
-    build_allowed_hosts,
-    build_csrf_trusted_origins,
-    get_env_bool,
-    get_secret_key,
-)
+from .base import BASE_DIR, get_env_bool, get_secret_key
 
 DEBUG = get_env_bool("DJANGO_DEBUG", default=False)
 
 SECRET_KEY = get_secret_key(DEBUG)
-
-ALLOWED_HOSTS = build_allowed_hosts(["localhost", "127.0.0.1", "0.0.0.0"])
-CSRF_TRUSTED_ORIGINS = build_csrf_trusted_origins(ALLOWED_HOSTS)
 
 STATICFILES_DIRS = [BASE_DIR / "static"]
 


### PR DESCRIPTION
## Summary
- define ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS in base settings using environment variables with updated defaults
- simplify dev and prod settings to rely on the shared host configuration

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e3d05202088326b59b763330f15bb0