### PR TITLE
Configure staticfiles storage for whitenoise

### DIFF
--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -150,6 +150,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATICFILES_DIRS: list[str] = []
 STATIC_ROOT = BASE_DIR / 'staticfiles'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'


### PR DESCRIPTION
## Summary
- set STATICFILES_STORAGE to use WhiteNoise's compressed manifest backend in the shared settings to match production storage configuration

## Testing
- python manage.py collectstatic --noinput

------
https://chatgpt.com/codex/tasks/task_e_68e3d31b853883269e45f7c3af197595