### PR TITLE
Add SECURE_PROXY_SSL_HEADER for proxy deployments

### DIFF
--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -46,6 +46,7 @@ CSRF_TRUSTED_ORIGINS = os.getenv(
     "CSRF_TRUSTED_ORIGINS",
     "https://consultant-app-156x.onrender.com,https://*.onrender.com",
 ).split(",")
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 
 def _get_sample_rate(name: str, default: float) -> float:


### PR DESCRIPTION
## Summary
- add `SECURE_PROXY_SSL_HEADER` to the shared settings so Django respects proxy SSL headers

## Testing
- DJANGO_SECRET_KEY=test python manage.py check --settings=backend.settings.prod

------
https://chatgpt.com/codex/tasks/task_e_68e3d314c5608326a405fc1ae632c27d