### PR TITLE
Add JWT role middleware and dashboard tests

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -3,3 +3,4 @@
 - The application exposes a lightweight health endpoint at `/health/` that returns a JSON payload containing the service status and database connectivity indicator.
 - Configure your hosting platform or uptime monitoring tool to poll this endpoint for availability checks.
 - Because the endpoint avoids opening new database connections, it remains responsive even when the database is under load or temporarily unavailable.
+- JWT-protected dashboards expect tokens signed with ``JWT_AUTH_SECRET`` (defaults to ``SECRET_KEY`` when unset). Set ``JWT_AUTH_ALGORITHM`` (default ``HS256``) or ``JWT_AUTH_ALGORITHMS`` for multi-algorithm validation when configuring external identity providers.

--- a/apps/users/jwt_utils.py
+++ b/apps/users/jwt_utils.py
@@ -1,0 +1,98 @@
+"""Utilities for decoding and validating JWT bearer tokens."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence, Set
+
+import jwt
+from django.conf import settings
+from jwt import InvalidTokenError
+
+from apps.users.constants import UserRole
+
+
+class JWTValidationError(Exception):
+    """Raised when a JWT token cannot be decoded or validated."""
+
+
+def _normalise_algorithms(value: Iterable[str] | str | None) -> Sequence[str]:
+    if not value:
+        return ("HS256",)
+
+    if isinstance(value, str):
+        return (value,)
+
+    return tuple(value)
+
+
+def extract_bearer_token(auth_header: str | None) -> str | None:
+    """Return the JWT token from a standard ``Authorization`` header."""
+
+    if not auth_header:
+        return None
+
+    parts = auth_header.split()
+    if len(parts) != 2:
+        return None
+
+    prefix, token = parts
+    if prefix.lower() != "bearer" or not token:
+        return None
+
+    return token
+
+
+def decode_roles(token: str) -> Set[UserRole]:
+    """Decode ``token`` and return the declared roles as :class:`UserRole`."""
+
+    if not token:
+        raise JWTValidationError("Bearer token is missing.")
+
+    secret = getattr(settings, "JWT_AUTH_SECRET", None) or settings.SECRET_KEY
+    algorithms = _normalise_algorithms(
+        getattr(settings, "JWT_AUTH_ALGORITHMS", None)
+        or getattr(settings, "JWT_AUTH_ALGORITHM", None)
+    )
+
+    try:
+        payload = jwt.decode(
+            token,
+            secret,
+            algorithms=list(algorithms),
+            options={"verify_aud": False},
+        )
+    except InvalidTokenError as exc:  # pragma: no cover - delegated to jwt
+        raise JWTValidationError("Invalid JWT token") from exc
+
+    raw_roles = payload.get("roles")
+    if raw_roles is None:
+        return set()
+
+    if isinstance(raw_roles, (list, tuple, set)):
+        role_values = raw_roles
+    else:
+        role_values = [raw_roles]
+
+    roles: Set[UserRole] = set()
+    for role in role_values:
+        if isinstance(role, UserRole):
+            roles.add(role)
+            continue
+        if not isinstance(role, str):
+            raise JWTValidationError("Roles claim must contain strings.")
+        try:
+            roles.add(UserRole(role.lower()))
+        except ValueError as exc:
+            raise JWTValidationError(f"Unknown role: {role}") from exc
+
+    return roles
+
+
+def roles_from_authorization_header(auth_header: str | None) -> Set[UserRole]:
+    """Decode the provided ``Authorization`` header and return the roles."""
+
+    token = extract_bearer_token(auth_header)
+    if not token:
+        return set()
+
+    return decode_roles(token)

--- a/apps/users/middleware.py
+++ b/apps/users/middleware.py
@@ -1,0 +1,42 @@
+"""Middleware for attaching JWT-derived role information to requests."""
+
+from __future__ import annotations
+
+from typing import Set
+
+from apps.users.constants import UserRole
+from apps.users.jwt_utils import JWTValidationError, roles_from_authorization_header
+from apps.users.permissions import user_has_role
+
+
+class JWTAuthenticationMiddleware:
+    """Decode bearer tokens and expose their roles on the request object."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        roles, token_present = self._resolve_roles(request)
+        request.jwt_roles = roles
+        request.jwt_token_present = token_present
+        return self.get_response(request)
+
+    def _resolve_roles(self, request) -> tuple[Set[UserRole], bool]:
+        auth_header = request.META.get("HTTP_AUTHORIZATION")
+        if auth_header:
+            try:
+                return roles_from_authorization_header(auth_header), True
+            except JWTValidationError:
+                return set(), True
+
+        user = getattr(request, "user", None)
+        if getattr(user, "is_authenticated", False):
+            derived_roles = {
+                role
+                for role in UserRole
+                if user_has_role(user, role)
+            }
+            if derived_roles:
+                return derived_roles, False
+
+        return set(), False

--- a/apps/users/permissions.py
+++ b/apps/users/permissions.py
@@ -70,6 +70,13 @@ def role_required(*roles: RoleLike):
             if getattr(user, "is_superuser", False):
                 return view_func(request, *args, **kwargs)
 
+            request_roles = getattr(request, "jwt_roles", None)
+            token_present = getattr(request, "jwt_token_present", False)
+            if request_roles is not None and (token_present or request_roles):
+                if any(role in request_roles for role in normalised_roles):
+                    return view_func(request, *args, **kwargs)
+                raise PermissionDenied
+
             if not user.groups.filter(name__in=allowed_groups).exists():
                 raise PermissionDenied
 

--- a/apps/users/tests/test_jwt_dashboards.py
+++ b/apps/users/tests/test_jwt_dashboards.py
@@ -1,0 +1,88 @@
+"""Tests for JWT-authenticated dashboard routing."""
+
+from __future__ import annotations
+
+import jwt
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from apps.users.constants import UserRole
+
+
+@pytest.fixture
+def jwt_config(settings):
+    settings.JWT_AUTH_SECRET = "test-secret"
+    settings.JWT_AUTH_ALGORITHM = "HS256"
+    settings.JWT_AUTH_ALGORITHMS = None
+    return settings
+
+
+@pytest.fixture
+def user(db):
+    return get_user_model().objects.create_user(
+        username="jwt-user", email="jwt@example.com", password="password123"
+    )
+
+
+def _token(settings, role: UserRole) -> str:
+    return jwt.encode(
+        {"roles": [role.value]},
+        settings.JWT_AUTH_SECRET,
+        algorithm=settings.JWT_AUTH_ALGORITHM,
+    )
+
+
+@pytest.mark.django_db
+def test_board_token_redirects_to_decisions_dashboard(client, jwt_config, user):
+    client.force_login(user)
+    token = _token(jwt_config, UserRole.BOARD)
+
+    response = client.get(
+        reverse("dashboard"),
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+    assert response.status_code == 302
+    assert response.url == reverse("decisions_dashboard")
+
+    decisions_response = client.get(
+        response.url,
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert decisions_response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_staff_token_redirects_to_vetting_dashboard(client, jwt_config, user):
+    client.force_login(user)
+    token = _token(jwt_config, UserRole.STAFF)
+
+    response = client.get(
+        reverse("dashboard"),
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+    assert response.status_code == 302
+    assert response.url == reverse("vetting_dashboard")
+
+    vetting_response = client.get(
+        response.url,
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+    assert vetting_response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_consultant_token_receives_consultant_dashboard(client, jwt_config, user):
+    client.force_login(user)
+    token = _token(jwt_config, UserRole.CONSULTANT)
+
+    response = client.get(
+        reverse("dashboard"),
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+    assert response.status_code == 200
+    template_names = {template.name for template in response.templates if template.name}
+    assert "dashboard.html" in template_names

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -8,7 +8,6 @@ from django.views.decorators.http import require_POST
 
 from apps.consultants.models import Consultant
 from apps.users.constants import CONSULTANTS_GROUP_NAME, UserRole as Roles
-from apps.users.permissions import user_has_role
 
 def register(request):
     if request.method == 'POST':
@@ -37,13 +36,15 @@ def logout_view(request):
 def dashboard(request):
     user = request.user
 
-    if user_has_role(user, Roles.BOARD):
+    roles = getattr(request, "jwt_roles", set())
+
+    if Roles.BOARD in roles:
         return redirect('decisions_dashboard')
 
-    if user_has_role(user, Roles.STAFF):
+    if Roles.STAFF in roles:
         return redirect('vetting_dashboard')
 
-    if not user_has_role(user, Roles.CONSULTANT):
+    if Roles.CONSULTANT not in roles:
         raise PermissionDenied
 
     application = Consultant.objects.filter(user=user).first()

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -99,6 +99,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'apps.users.middleware.JWTAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
@@ -161,3 +162,14 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Configure monitoring once settings are imported.
 init_sentry()
+
+
+# JWT authentication configuration
+JWT_AUTH_SECRET = os.getenv("JWT_AUTH_SECRET")
+JWT_AUTH_ALGORITHM = os.getenv("JWT_AUTH_ALGORITHM", "HS256")
+_jwt_algorithms_env = os.getenv("JWT_AUTH_ALGORITHMS")
+JWT_AUTH_ALGORITHMS = (
+    tuple(algo.strip() for algo in _jwt_algorithms_env.split(",") if algo.strip())
+    if _jwt_algorithms_env
+    else None
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ Django==5.2.6
 gunicorn==23.0.0
 packaging==25.0
 pillow==11.3.0
+PyJWT==2.8.0
 psycopg2-binary==2.9.10
 sqlparse==0.5.3
 whitenoise==6.11.0


### PR DESCRIPTION
## Summary
- add JWT decoding utilities and middleware to expose JWT roles on each request
- update dashboard entry points and permissions to rely on decoded roles and document the new JWT settings
- cover the dashboard routing scenarios with signed role tokens and add the PyJWT dependency

## Testing
- pytest -c /tmp/pytest_jwt.ini apps/users/tests/test_jwt_dashboards.py

------
https://chatgpt.com/codex/tasks/task_e_68e3d4e4ae9083268169180e20710656