### PR TITLE
Add admin impersonation workflow

### DIFF
--- a/apps/users/templates/impersonation_dashboard.html
+++ b/apps/users/templates/impersonation_dashboard.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+{% block title %}Impersonation Dashboard{% endblock %}
+
+{% block content %}
+<section class="page-stack">
+    <div class="form-card wide">
+        <h1>Impersonation dashboard</h1>
+        <p class="description">
+            Select a user to impersonate. While impersonating, your original administrator session is preserved and can be restored at any time.
+        </p>
+        <form method="get" class="impersonation-search">
+            <label for="user-search">Search users</label>
+            <div class="impersonation-search__controls">
+                <input id="user-search" type="search" name="q" value="{{ query }}" placeholder="Search by username">
+                <button type="submit" class="btn-secondary">Search</button>
+            </div>
+        </form>
+        {% if is_impersonating %}
+            <div class="impersonation-warning">
+                You are currently impersonating another account. Stop the active session before starting a new impersonation.
+            </div>
+        {% endif %}
+        <div class="impersonation-table">
+            <table>
+                <thead>
+                    <tr>
+                        <th scope="col">Username</th>
+                        <th scope="col">Email</th>
+                        <th scope="col" class="actions">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                {% for user in users %}
+                    <tr>
+                        <td>{{ user.username }}</td>
+                        <td>{{ user.email|default:"—" }}</td>
+                        <td class="actions">
+                            <form method="post" action="{% url 'start_impersonation' %}">
+                                {% csrf_token %}
+                                <input type="hidden" name="user_id" value="{{ user.pk }}">
+                                <button type="submit" class="btn-primary" {% if is_impersonating %}disabled{% endif %}>Impersonate</button>
+                            </form>
+                        </td>
+                    </tr>
+                {% empty %}
+                    <tr>
+                        <td colspan="3" class="empty">No users found.</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -8,6 +8,9 @@ urlpatterns = [
     path('logout/', views.logout_view, name='logout'),
     path('register/', views.register, name='register'),
     path('dashboard/', views.dashboard, name='dashboard'),
+    path('impersonation/', views.impersonation_dashboard, name='impersonation_dashboard'),
+    path('impersonation/start/', views.start_impersonation, name='start_impersonation'),
+    path('impersonation/stop/', views.stop_impersonation, name='stop_impersonation'),
     path('', home_view, name='home'),
 ]
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -311,3 +311,118 @@
 .back-link a:focus-visible {
     text-decoration: underline;
 }
+
+.impersonation-banner {
+    background: linear-gradient(135deg, rgba(59, 130, 246, 0.12), rgba(59, 130, 246, 0.22));
+    border-bottom: 1px solid rgba(37, 99, 235, 0.35);
+    padding: 0.9rem clamp(1rem, 5vw, 3rem);
+    color: #1e3a8a;
+}
+
+.impersonation-banner__content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.impersonation-banner strong {
+    font-weight: 600;
+}
+
+.impersonation-banner__form {
+    margin: 0;
+}
+
+.btn-stop-impersonation {
+    border: none;
+    border-radius: 10px;
+    padding: 0.55rem 1.1rem;
+    background: #1d4ed8;
+    color: #ffffff;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 10px 22px -15px rgba(29, 78, 216, 0.75);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-stop-impersonation:hover,
+.btn-stop-impersonation:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 24px -16px rgba(29, 78, 216, 0.85);
+}
+
+.impersonation-search {
+    display: grid;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.impersonation-search label {
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.impersonation-search__controls {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.impersonation-search input[type="search"] {
+    flex: 1 1 220px;
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.6);
+    padding: 0.55rem 0.85rem;
+    font-size: 0.95rem;
+    background-color: #f8fafc;
+}
+
+.impersonation-search input[type="search"]:focus {
+    outline: none;
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+    background-color: #ffffff;
+}
+
+.impersonation-table table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.impersonation-table thead {
+    background: rgba(148, 163, 184, 0.18);
+}
+
+.impersonation-table th,
+.impersonation-table td {
+    text-align: left;
+    padding: 0.75rem;
+    font-size: 0.95rem;
+}
+
+.impersonation-table tbody tr:nth-child(even) {
+    background: rgba(241, 245, 249, 0.8);
+}
+
+.impersonation-table td.actions {
+    width: 160px;
+}
+
+.impersonation-table td.empty {
+    text-align: center;
+    color: #64748b;
+}
+
+.impersonation-warning {
+    margin-bottom: 1.25rem;
+    padding: 0.85rem 1rem;
+    border-radius: 10px;
+    background: rgba(249, 115, 22, 0.14);
+    border: 1px solid rgba(249, 115, 22, 0.35);
+    color: #c2410c;
+    font-size: 0.9rem;
+    line-height: 1.4;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,6 +15,11 @@
         <div class="brand">Consultant App</div>
         <nav class="site-nav">
         {% if user.is_authenticated %}
+            {% with user_is_admin=user.is_superuser or user.groups.filter(name='Admins').exists %}
+                {% if user_is_admin %}
+                    <a class="nav-link" href="{% url 'impersonation_dashboard' %}">Impersonation</a>
+                {% endif %}
+            {% endwith %}
             <form method="post" action="{% url 'logout' %}">
                 {% csrf_token %}
                 <button type="submit" class="btn-link">Logout</button>
@@ -25,6 +30,18 @@
         {% endif %}
         </nav>
     </header>
+
+    {% if request.session.impersonator_username %}
+    <div class="impersonation-banner">
+        <div class="impersonation-banner__content">
+            <span>You are impersonating <strong>{{ user.username }}</strong>. Original admin: <strong>{{ request.session.impersonator_username }}</strong>.</span>
+            <form method="post" action="{% url 'stop_impersonation' %}" class="impersonation-banner__form">
+                {% csrf_token %}
+                <button type="submit" class="btn-stop-impersonation">Stop impersonating</button>
+            </form>
+        </div>
+    </div>
+    {% endif %}
 
     <main class="page-content">
         {% block content %}


### PR DESCRIPTION
## Summary
- add admin-only impersonation views that switch accounts via the session
- introduce an impersonation dashboard, navigation entry, and prominent banner styling
- cover impersonation scenarios with unit tests and expose the new URLs

## Testing
- `pytest apps/users/tests.py` *(fails: repository pytest.ini has duplicate [pytest] section)*
- `python manage.py test apps.users.tests` *(fails: missing optional dependency `jwt` required by existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d7cb53908326905ada72871d537d