### PR TITLE
Add consultant submission tests and fixtures

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,4 @@
-# pytest.ini
-[pytest]
-DJANGO_SETTINGS_MODULE = config.settings
-python_files = tests/test_*.py
-python_paths = .
 [pytest]
 DJANGO_SETTINGS_MODULE = backend.settings.dev
+python_files = tests/test_*.py
+pythonpath = .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import pytest
 from django.contrib.auth import get_user_model
-from apps.users.constants import UserRole as Roles
+from django.contrib.auth.models import Group
+
+from apps.users.constants import ROLE_GROUP_MAP, UserRole as Roles
 
 User = get_user_model()
 
@@ -8,7 +10,12 @@ User = get_user_model()
 def user_factory(db):
     def create_user(username="testuser", role=Roles.CONSULTANT):
         user = User.objects.create_user(username=username, password="password123")
-        user.role = role  # or assign user.groups.add(...) if using Django groups
+        user.role = role
         user.save()
+
+        for group_name in ROLE_GROUP_MAP.get(role, set()):
+            group, _ = Group.objects.get_or_create(name=group_name)
+            user.groups.add(group)
+
         return user
     return create_user

--- a/tests/test_consultant_form.py
+++ b/tests/test_consultant_form.py
@@ -1,0 +1,41 @@
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from apps.consultants.forms import ConsultantForm
+
+from tests.utils import consultant_form_data, consultant_form_files
+
+
+@pytest.mark.django_db
+def test_consultant_form_requires_documents_on_submit():
+    data = consultant_form_data()
+    files = consultant_form_files()
+    files.pop("cv")
+
+    form = ConsultantForm(data=data, files=files)
+
+    assert not form.is_valid()
+    assert "This document is required." in form.errors["cv"]
+
+
+@pytest.mark.django_db
+def test_consultant_form_allows_draft_without_documents():
+    data = consultant_form_data(action="draft")
+    form = ConsultantForm(data=data)
+
+    assert form.is_valid()
+
+
+@pytest.mark.django_db
+def test_consultant_form_rejects_invalid_file_type():
+    data = consultant_form_data()
+    files = consultant_form_files(
+        id_document=SimpleUploadedFile(
+            "id.txt", b"text content", content_type="text/plain"
+        )
+    )
+
+    form = ConsultantForm(data=data, files=files)
+
+    assert not form.is_valid()
+    assert "Only PDF, JPG, or PNG files are allowed." in form.errors["id_document"]

--- a/tests/test_submit_application.py
+++ b/tests/test_submit_application.py
@@ -1,36 +1,88 @@
 import pytest
+from django.contrib.messages import get_messages
 from django.urls import reverse
-from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
+
 from apps.users.constants import UserRole as Roles
 from apps.consultants.models import Consultant
 
+from tests.utils import (
+    consultant_form_data,
+    consultant_form_files,
+    create_consultant_instance,
+)
+
+
 @pytest.mark.django_db
 def test_submit_application_success(client, user_factory, mocker):
-    # Setup user with CONSULTANT role
     user = user_factory(role=Roles.CONSULTANT)
     client.force_login(user)
 
-    # Mock the email send function
     mock_send = mocker.patch(
         "apps.consultants.views.send_submission_confirmation_email"
     )
 
-    # Build form data
-    data = {
-        "action": "submit",
-        "cv": SimpleUploadedFile("cv.pdf", b"file content", content_type="application/pdf"),
-        "experience": "5 years consulting experience",
-        "reference_letter": SimpleUploadedFile("ref.pdf", b"file content", content_type="application/pdf"),
-        "passport_photo": SimpleUploadedFile("photo.jpg", b"fakeimage", content_type="image/jpeg"),
-    }
+    payload = {**consultant_form_data(), **consultant_form_files()}
 
-    # Post to submit_application view
     url = reverse("submit_application")
-    response = client.post(url, data, follow=True)
+    response = client.post(url, payload)
 
-    # Assertions
-    assert response.status_code == 200
+    assert response.status_code == 302
+    assert response["Location"].endswith(reverse("dashboard"))
     consultant = Consultant.objects.get(user=user)
     assert consultant.status == "submitted"
     assert consultant.submitted_at is not None
     mock_send.assert_called_once_with(consultant)
+
+
+@pytest.mark.django_db
+def test_submit_application_redirects_when_already_submitted(client, user_factory):
+    user = user_factory(role=Roles.CONSULTANT)
+    create_consultant_instance(
+        user,
+        status="submitted",
+        submitted_at=timezone.now(),
+    )
+    client.force_login(user)
+
+    url = reverse("submit_application")
+    response = client.get(url)
+
+    assert response.status_code == 302
+    assert response["Location"].endswith(reverse("dashboard"))
+
+    messages = list(get_messages(response.wsgi_request))
+    assert any(
+        message.message == "You have already submitted your application."
+        and message.level_tag == "info"
+        for message in messages
+    )
+    assert Consultant.objects.filter(user=user).count() == 1
+
+
+@pytest.mark.django_db
+def test_submit_application_handles_email_failure(client, user_factory, mocker):
+    user = user_factory(role=Roles.CONSULTANT)
+    client.force_login(user)
+
+    mock_send = mocker.patch(
+        "apps.consultants.views.send_submission_confirmation_email",
+        side_effect=Exception("email failure"),
+    )
+
+    payload = {**consultant_form_data(), **consultant_form_files()}
+
+    url = reverse("submit_application")
+    response = client.post(url, payload)
+
+    consultant = Consultant.objects.get(user=user)
+    assert consultant.status == "submitted"
+    assert consultant.submitted_at is not None
+    mock_send.assert_called_once_with(consultant)
+
+    messages = list(get_messages(response.wsgi_request))
+    assert any(
+        "confirmation email failed" in message.message
+        and message.level_tag == "warning"
+        for message in messages
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,75 @@
+from datetime import date
+from io import BytesIO
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image
+
+from apps.consultants.models import Consultant
+
+
+def _generate_png_bytes() -> bytes:
+    image = Image.new("RGB", (1, 1), color="white")
+    buffer = BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+PNG_IMAGE_BYTES = _generate_png_bytes()
+PDF_BYTES = b"%PDF-1.4 test pdf content"
+
+
+def consultant_form_data(action="submit", **overrides):
+    data = {
+        "full_name": "Test Consultant",
+        "id_number": "ID123456",
+        "dob": "1990-01-01",
+        "gender": "M",
+        "nationality": "Testland",
+        "email": "consultant@example.com",
+        "phone_number": "+1234567890",
+        "business_name": "Test Consulting LLC",
+        "registration_number": "REG123",
+        "action": action,
+    }
+    data.update(overrides)
+    return data
+
+
+def consultant_form_files(**overrides):
+    files = {
+        "photo": SimpleUploadedFile(
+            "photo.png", PNG_IMAGE_BYTES, content_type="image/png"
+        ),
+        "id_document": SimpleUploadedFile(
+            "id.pdf", PDF_BYTES, content_type="application/pdf"
+        ),
+        "cv": SimpleUploadedFile("cv.pdf", PDF_BYTES, content_type="application/pdf"),
+        "police_clearance": SimpleUploadedFile(
+            "police.pdf", PDF_BYTES, content_type="application/pdf"
+        ),
+        "qualifications": SimpleUploadedFile(
+            "qualifications.pdf", PDF_BYTES, content_type="application/pdf"
+        ),
+        "business_certificate": SimpleUploadedFile(
+            "business.pdf", PDF_BYTES, content_type="application/pdf"
+        ),
+    }
+    files.update(overrides)
+    return files
+
+
+def create_consultant_instance(user, **overrides):
+    defaults = {
+        "user": user,
+        "full_name": "Existing Consultant",
+        "id_number": "ID987654",
+        "dob": date(1985, 5, 1),
+        "gender": "M",
+        "nationality": "Testland",
+        "email": "existing@example.com",
+        "phone_number": "+1987654321",
+        "business_name": "Existing Consulting Ltd",
+        "registration_number": "REG999",
+    }
+    defaults.update(overrides)
+    return Consultant.objects.create(**defaults)


### PR DESCRIPTION
## Summary
- fix the pytest configuration to point at the Django settings used by the project
- update the shared user factory to assign users to the correct role groups
- add utilities and tests that exercise the consultant application form and submission flow

## Testing
- pytest tests/test_consultant_form.py tests/test_submit_application.py

------
https://chatgpt.com/codex/tasks/task_e_68e4b57fc074832693ddc2d7bf688dda