### PR TITLE
Add role-based login redirects

### DIFF
--- a/apps/users/tests/test_login_redirects.py
+++ b/apps/users/tests/test_login_redirects.py
@@ -1,0 +1,80 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.urls import reverse
+from django.test import TestCase
+
+
+class RoleBasedLoginViewTests(TestCase):
+    def setUp(self):
+        self.login_url = reverse('login')
+        self.password = 'testpass123'
+
+    def _create_user(self, username='user', **extra_fields):
+        user_model = get_user_model()
+        user = user_model.objects.create_user(
+            username=username,
+            password=self.password,
+            email=f'{username}@example.com',
+            **extra_fields,
+        )
+        return user
+
+    def test_superuser_redirects_to_admin_dashboard(self):
+        user = self._create_user('superuser', is_superuser=True, is_staff=True)
+
+        response = self.client.post(
+            self.login_url,
+            {'username': user.username, 'password': self.password},
+        )
+
+        self.assertRedirects(response, '/admin-dashboard/', fetch_redirect_response=False)
+
+    def test_staff_group_redirects_to_staff_dashboard(self):
+        staff_group, _ = Group.objects.get_or_create(name='Staff')
+        user = self._create_user('staffuser')
+        user.groups.add(staff_group)
+
+        response = self.client.post(
+            self.login_url,
+            {'username': user.username, 'password': self.password},
+        )
+
+        self.assertRedirects(response, '/staff-dashboard/', fetch_redirect_response=False)
+
+    def test_applicant_group_redirects_to_applicant_dashboard(self):
+        applicant_group, _ = Group.objects.get_or_create(name='Applicant')
+        user = self._create_user('applicantuser')
+        user.groups.add(applicant_group)
+
+        response = self.client.post(
+            self.login_url,
+            {'username': user.username, 'password': self.password},
+        )
+
+        self.assertRedirects(response, '/applicant-dashboard/', fetch_redirect_response=False)
+
+    def test_next_parameter_takes_priority(self):
+        applicant_group, _ = Group.objects.get_or_create(name='Applicant')
+        user = self._create_user('priorityuser')
+        user.groups.add(applicant_group)
+
+        response = self.client.post(
+            f"{self.login_url}?next=/custom-destination/",
+            {'username': user.username, 'password': self.password},
+        )
+
+        self.assertRedirects(
+            response,
+            '/custom-destination/',
+            fetch_redirect_response=False,
+        )
+
+    def test_default_redirect_remains_dashboard(self):
+        user = self._create_user('defaultuser')
+
+        response = self.client.post(
+            self.login_url,
+            {'username': user.username, 'password': self.password},
+        )
+
+        self.assertRedirects(response, '/dashboard/', fetch_redirect_response=False)

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,10 +1,9 @@
 from django.urls import path
-from django.contrib.auth import views as auth_views
 from . import views
-from .views import home_view
+from .views import RoleBasedLoginView, home_view
 
 urlpatterns = [
-    path('login/', auth_views.LoginView.as_view(template_name='registration/login.html'), name='login'),
+    path('login/', RoleBasedLoginView.as_view(template_name='registration/login.html'), name='login'),
     path('logout/', views.logout_view, name='logout'),
     path('register/', views.register, name='register'),
     path('dashboard/', views.dashboard, name='dashboard'),


### PR DESCRIPTION
## Summary
- add a custom login view that routes users to admin, staff, or applicant dashboards after authentication
- update the login URL to use the new view and cover the behavior with dedicated tests

## Testing
- pytest apps/users/tests/test_login_redirects.py

------
https://chatgpt.com/codex/tasks/task_e_68e4cb92b1748326925dbc9b607b55d4