### PR TITLE
Add login redirect test for anonymous vetting dashboard access

### DIFF
--- a/apps/vetting/tests.py
+++ b/apps/vetting/tests.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.test import TestCase, Client
 from django.contrib.auth.models import User, Group
 from django.urls import reverse
+from django.conf import settings
 from apps.consultants.models import Consultant
 from apps.decisions.models import ApplicationAction
 from apps.users.constants import COUNTERSTAFF_GROUP_NAME, BOARD_COMMITTEE_GROUP_NAME
@@ -66,6 +67,16 @@ class VettingDashboardViewTests(TestCase):
 
         response = self.client.get(reverse('vetting_dashboard'))
         self.assertEqual(response.status_code, 403)
+
+    def test_anonymous_user_redirects_to_login(self):
+        anonymous_client = Client()
+
+        response = anonymous_client.get(reverse('vetting_dashboard'))
+
+        self.assertEqual(response.status_code, 302)
+        login_url = settings.LOGIN_URL
+        expected_url = f"{login_url}?next={reverse('vetting_dashboard')}"
+        self.assertEqual(response.url, expected_url)
 
     @patch('apps.decisions.services.transaction.on_commit')
     @patch('apps.decisions.services.generate_rejection_letter_task.delay')


### PR DESCRIPTION
## Summary
- add a regression test verifying anonymous users hitting the vetting dashboard are redirected to the login view
- derive the expected login target from the configured LOGIN_URL to ensure the check follows project settings

## Testing
- pytest --import-mode=importlib apps/vetting/tests.py::VettingDashboardViewTests::test_anonymous_user_redirects_to_login

------
https://chatgpt.com/codex/tasks/task_e_68e4d211dea48326bf09454cee151a9f