### PR TITLE
Show pending consultants on review dashboard

### DIFF
--- a/apps/decisions/tests.py
+++ b/apps/decisions/tests.py
@@ -113,6 +113,21 @@ class DecisionsViewTests(TestCase):
         self.client.force_login(self.non_reviewer)
         self.assertEqual(self.client.get(url).status_code, 403)
 
+    def test_decisions_dashboard_lists_pending_applications(self):
+        url = reverse("decisions_dashboard")
+
+        self.client.force_login(self.board_user)
+        response = self.client.get(url)
+
+        consultants = list(response.context["consultants"])
+        self.assertEqual(
+            [consultant.full_name for consultant in consultants],
+            ["Submitted Applicant", "Vetted Applicant"],
+        )
+        self.assertTrue(
+            all(consultant.status in {"submitted", "vetted"} for consultant in consultants)
+        )
+
     def test_applications_list_access_control(self):
         url = reverse("officer_applications_list")
 

--- a/apps/decisions/views.py
+++ b/apps/decisions/views.py
@@ -61,12 +61,12 @@ def reviewer_required(view_func):
 
 @reviewer_required
 def decisions_dashboard(request):
-    """Dashboard for reviewers to see vetted applications and record actions."""
+    """Dashboard for reviewers to see submitted/vetted applications and record actions."""
 
     consultants = (
-        Consultant.objects.filter(status="vetted")
+        Consultant.objects.filter(status__in=["submitted", "vetted"])
         .select_related("user")
-        .order_by("full_name")
+        .order_by("status", "-submitted_at", "full_name")
     )
 
     form = ActionForm()

--- a/templates/officer/decisions_dashboard.html
+++ b/templates/officer/decisions_dashboard.html
@@ -17,7 +17,7 @@
   <section class="data-card">
     <div class="card-header">
       <h2>Applications requiring decisions</h2>
-      <p class="card-subtitle">Review recently vetted submissions and record the final outcome.</p>
+      <p class="card-subtitle">Review submitted and vetted applications to record the next decision.</p>
     </div>
 
     {% if consultants %}
@@ -90,7 +90,7 @@
       </table>
     </div>
     {% else %}
-    <p class="card-subtitle">There are currently no vetted applications awaiting a decision.</p>
+    <p class="card-subtitle">There are currently no submitted or vetted applications awaiting a decision.</p>
     {% endif %}
   </section>
 </div>


### PR DESCRIPTION
## Summary
- surface consultants with submitted or vetted status on the review dashboard
- refresh dashboard copy to describe the broader scope of pending applications
- add coverage ensuring only pending consultants populate the dashboard list

## Testing
- pytest apps/decisions/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e4d4f32c8c8326bdd94ba57e326679