### PR TITLE
Add board dashboard view for submitted consultant applications

### DIFF
--- a/apps/users/context_processors.py
+++ b/apps/users/context_processors.py
@@ -1,6 +1,6 @@
 """Custom context processors for the users app."""
 
-from apps.users.views import _user_is_admin
+from apps.users.views import _user_is_admin, _user_is_board_or_staff
 
 
 def user_is_admin(request):
@@ -9,4 +9,12 @@ def user_is_admin(request):
         "user_is_admin": _user_is_admin(request.user)
         if request.user.is_authenticated
         else False,
+    }
+
+
+def user_is_board_or_staff(request):
+    """Expose whether the user can access the board dashboard."""
+
+    return {
+        "user_is_board_or_staff": _user_is_board_or_staff(request.user)
     }

--- a/apps/users/templates/board_dashboard.html
+++ b/apps/users/templates/board_dashboard.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}Board Dashboard{% endblock %}
+
+{% block content %}
+<section class="page-section">
+    <h1>Submitted Consultant Applications</h1>
+    {% if consultants %}
+    <div class="table-responsive">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th scope="col">Full name</th>
+                    <th scope="col">ID number</th>
+                    <th scope="col">Phone number</th>
+                    <th scope="col">Business name</th>
+                    <th scope="col">Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for consultant in consultants %}
+                <tr>
+                    <td>{{ consultant.full_name }}</td>
+                    <td>{{ consultant.id_number }}</td>
+                    <td>{{ consultant.phone_number }}</td>
+                    <td>{{ consultant.business_name }}</td>
+                    <td class="status">{{ consultant.get_status_display }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% else %}
+    <p>No submitted applications found.</p>
+    {% endif %}
+</section>
+{% endblock %}

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('logout/', views.logout_view, name='logout'),
     path('register/', views.register, name='register'),
     path('dashboard/', views.dashboard, name='dashboard'),
+    path('board/', views.board_dashboard, name='board_dashboard'),
     path('impersonation/', views.impersonation_dashboard, name='impersonation_dashboard'),
     path('impersonation/start/', views.start_impersonation, name='start_impersonation'),
     path('impersonation/stop/', views.stop_impersonation, name='stop_impersonation'),

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -119,6 +119,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'apps.users.context_processors.user_is_admin',
+                'apps.users.context_processors.user_is_board_or_staff',
             ],
         },
     },

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,9 @@
             {% if user_is_admin %}
                 <a class="nav-link" href="{% url 'impersonation_dashboard' %}">Impersonation</a>
             {% endif %}
+            {% if user_is_board_or_staff %}
+                <a class="nav-link" href="{% url 'board_dashboard' %}">Board dashboard</a>
+            {% endif %}
             <form method="post" action="{% url 'logout' %}">
                 {% csrf_token %}
                 <button type="submit" class="btn-link">Logout</button>


### PR DESCRIPTION
## Summary
- add a board dashboard view restricted to Board and Staff groups that lists submitted consultant applications
- provide a dedicated template and navigation link for the read-only board dashboard
- expose a context processor for board/staff access and register the route in the users URLs

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68e4e1d08c208326b1c4d5926889550e