### PR TITLE
Add application status counts to staff dashboard

### DIFF
--- a/apps/users/templates/staff_dashboard.html
+++ b/apps/users/templates/staff_dashboard.html
@@ -3,7 +3,36 @@
 {% block title %}Staff Dashboard{% endblock %}
 
 {% block content %}
-  <h2>Submitted Consultant Applications</h2>
+  <h2>Staff Dashboard</h2>
+
+  <section class="row g-3 mb-4">
+    <div class="col-12 col-sm-6 col-lg-3">
+      <div class="border rounded p-3 bg-light h-100">
+        <p class="text-muted text-uppercase small mb-1">Draft</p>
+        <p class="h4 mb-0">{{ status_counts.draft|default:0 }}</p>
+      </div>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <div class="border rounded p-3 bg-light h-100">
+        <p class="text-muted text-uppercase small mb-1">Submitted</p>
+        <p class="h4 mb-0">{{ status_counts.submitted|default:0 }}</p>
+      </div>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <div class="border rounded p-3 bg-light h-100">
+        <p class="text-muted text-uppercase small mb-1">Approved</p>
+        <p class="h4 mb-0">{{ status_counts.approved|default:0 }}</p>
+      </div>
+    </div>
+    <div class="col-12 col-sm-6 col-lg-3">
+      <div class="border rounded p-3 bg-light h-100">
+        <p class="text-muted text-uppercase small mb-1">Rejected</p>
+        <p class="h4 mb-0">{{ status_counts.rejected|default:0 }}</p>
+      </div>
+    </div>
+  </section>
+
+  <h2 class="h4">Submitted Consultant Applications</h2>
 
   {% if consultants %}
     <p>Select an action for each application and optionally leave an internal comment.</p>

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -8,6 +8,7 @@ from django.contrib.auth.views import LoginView
 from django.core.exceptions import PermissionDenied
 from django.views.decorators.http import require_POST
 from django.http import HttpResponseBadRequest
+from django.db.models import Count, Q
 
 from apps.consultants.models import Consultant
 from apps.users.constants import (
@@ -187,12 +188,20 @@ def staff_dashboard(request):
         .order_by("full_name")
     )
 
+    status_counts = Consultant.objects.aggregate(
+        draft=Count("id", filter=Q(status="draft")),
+        submitted=Count("id", filter=Q(status="submitted")),
+        rejected=Count("id", filter=Q(status="rejected")),
+        approved=Count("id", filter=Q(status="approved")),
+    )
+
     return render(
         request,
         "staff_dashboard.html",
         {
             "consultants": consultants,
             "allowed_actions": allowed_actions,
+            "status_counts": status_counts,
         },
     )
 


### PR DESCRIPTION
## Summary
- aggregate consultant application totals by status in the staff dashboard view
- display the new status summary tiles in the staff dashboard template

## Testing
- python manage.py test apps.users.tests.test_login_redirects -v 2

------
https://chatgpt.com/codex/tasks/task_e_68e50950ef108326b1509bf4cc3200ed