### PR TITLE
Add recent consultant applications table to staff dashboard

### DIFF
--- a/apps/users/templates/staff_dashboard.html
+++ b/apps/users/templates/staff_dashboard.html
@@ -32,6 +32,52 @@
     </div>
   </section>
 
+  <section class="card mb-4">
+    <div class="card-body">
+      <h3 class="h5 mb-3">Recent Applications</h3>
+
+      {% if recent_applications %}
+        <div class="table-responsive">
+          <table class="table table-sm align-middle mb-0">
+            <thead>
+              <tr>
+                <th scope="col">Full Name</th>
+                <th scope="col">Status</th>
+                <th scope="col">Submitted At</th>
+                <th scope="col" class="text-end">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for application in recent_applications %}
+                <tr>
+                  <td>{{ application.full_name }}</td>
+                  <td>{{ application.get_status_display }}</td>
+                  <td>
+                    {% if application.submitted_at %}
+                      {{ application.submitted_at|date:"M d, Y" }}
+                    {% else %}
+                      —
+                    {% endif %}
+                  </td>
+                  <td class="text-end">
+                    <a
+                      href="{% url 'officer_application_detail' application.pk %}"
+                      class="btn btn-outline-primary btn-sm"
+                    >
+                      View
+                    </a>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% else %}
+        <p class="mb-0 text-muted">No recent applications available.</p>
+      {% endif %}
+    </div>
+  </section>
+
   <h2 class="h4">Submitted Consultant Applications</h2>
 
   {% if consultants %}

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -188,6 +188,12 @@ def staff_dashboard(request):
         .order_by("full_name")
     )
 
+    recent_applications = (
+        Consultant.objects.exclude(submitted_at__isnull=True)
+        .select_related("user")
+        .order_by("-submitted_at", "-id")[:5]
+    )
+
     status_counts = Consultant.objects.aggregate(
         draft=Count("id", filter=Q(status="draft")),
         submitted=Count("id", filter=Q(status="submitted")),
@@ -202,6 +208,7 @@ def staff_dashboard(request):
             "consultants": consultants,
             "allowed_actions": allowed_actions,
             "status_counts": status_counts,
+            "recent_applications": recent_applications,
         },
     )
 


### PR DESCRIPTION
## Summary
- query the five most recent consultant applications for the staff dashboard
- render a recent applications table with name, status, submission date, and view action

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e50d40d5e4832690de1fb8d4df12c9