### PR TITLE
Improve staff consultant detail test coverage

### DIFF
--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -324,7 +324,7 @@ class StaffConsultantDetailViewTests(TestCase):
         self.assertIn(reverse("login"), response.url)
 
     def test_staff_can_view_consultant_detail(self):
-        self.client.login(username=self.staff_user.username, password=self.password)
+        self.client.force_login(self.staff_user)
         url = reverse("staff_consultant_detail", args=[self.consultant.pk])
 
         response = self.client.get(url)
@@ -333,6 +333,10 @@ class StaffConsultantDetailViewTests(TestCase):
         self.assertEqual(response.context["consultant"], self.consultant)
         self.assertContains(response, self.consultant.full_name)
         self.assertContains(response, self.consultant.business_name)
+        self.assertContains(response, f"mailto:{self.consultant.email}")
+        self.assertContains(response, self.consultant.phone_number)
+        self.assertContains(response, self.consultant.id_number)
+        self.assertContains(response, self.consultant.nationality)
 
     def test_non_staff_user_denied(self):
         self.client.login(username=self.regular_user.username, password=self.password)


### PR DESCRIPTION
## Summary
- update staff consultant detail view test to use force_login for authentication
- extend the test with content assertions for the fields shown on the staff consultant detail page

## Testing
- python manage.py test apps.users.tests

------
https://chatgpt.com/codex/tasks/task_e_68e51852f11c8326ae38c17e32e002f9