### PR TITLE
Remove legacy submit_application view duplicate

### DIFF
--- a/apps/consultants/views.py
+++ b/apps/consultants/views.py
@@ -26,45 +26,6 @@ def submit_application(request):
         if form.is_valid():
             consultant = form.save(commit=False)
             consultant.user = request.user
-            consultant.status = 'submitted' if is_submission else 'draft'
-            consultant.submitted_at = timezone.now() if is_submission else None
-            consultant.save()
-
-            if is_submission:
-                send_submission_confirmation_email(consultant)
-
-            message = (
-                "Application submitted successfully."
-                if is_submission
-                else "Draft saved. You can complete it later."
-            )
-            message_fn = messages.success if is_submission else messages.info
-            message_fn(request, message)
-
-            return redirect('dashboard')
-
-    return render(request, 'consultants/application_form.html', {
-        'form': form,
-        'is_editing': application is not None and application.status == 'draft',
-        'show_save_draft': application is None or application.status == 'draft',
-    })
-@role_required(Roles.CONSULTANT)
-def submit_application(request):
-    application = Consultant.objects.filter(user=request.user).first()
-
-    if application and application.status != 'draft':
-        messages.info(request, "You have already submitted your application.")
-        return redirect('dashboard')
-
-    form = ConsultantForm(request.POST or None, request.FILES or None, instance=application)
-
-    if request.method == 'POST':
-        action = request.POST.get('action', 'draft')
-        is_submission = action == 'submit'
-
-        if form.is_valid():
-            consultant = form.save(commit=False)
-            consultant.user = request.user
 
             if is_submission:
                 consultant.status = 'submitted'


### PR DESCRIPTION
## Summary
- remove the outdated `submit_application` implementation and retain the version that preserves draft submission timestamps
- ensure imports remain unchanged and URL patterns still reference the surviving view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e519de56c883269654193dafd272a9