### PR TITLE
Enhance consultant form styling and add draft auto-save

### DIFF
--- a/apps/consultants/tests.py
+++ b/apps/consultants/tests.py
@@ -1,4 +1,5 @@
 import io
+import json
 import shutil
 import tempfile
 from datetime import date, timedelta
@@ -290,3 +291,51 @@ class SubmitApplicationViewTests(TestCase):
 
         response = self.client.get(reverse('submit_application'))
         self.assertEqual(response.status_code, 403)
+
+
+class AutoSaveDraftViewTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.user = user_model.objects.create_user('autosaver', password='password123')
+        consultant_group, _ = Group.objects.get_or_create(name=CONSULTANTS_GROUP_NAME)
+        self.user.groups.add(consultant_group)
+        self.client.force_login(self.user)
+
+        self.consultant = Consultant.objects.create(
+            user=self.user,
+            full_name='Initial User',
+            id_number='ID123456',
+            dob=date(1985, 7, 1),
+            gender='M',
+            nationality='Originland',
+            email='initial@example.com',
+            phone_number='0700000000',
+            business_name='Initial Biz',
+            registration_number='REG-001',
+        )
+
+    def test_autosave_updates_only_changed_fields(self):
+        url = reverse('autosave_consultant_draft')
+        payload = {
+            'phone_number': '0712345678',
+            'business_name': 'Initial Biz',
+        }
+
+        response = self.client.post(
+            url,
+            data=json.dumps(payload),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['status'], 'saved')
+        self.assertIn('timestamp', body)
+
+        self.consultant.refresh_from_db()
+        self.assertEqual(self.consultant.phone_number, '0712345678')
+        self.assertEqual(self.consultant.full_name, 'Initial User')
+        self.assertEqual(self.consultant.id_number, 'ID123456')
+        self.assertEqual(self.consultant.business_name, 'Initial Biz')
+        self.assertEqual(self.consultant.registration_number, 'REG-001')
+        self.assertEqual(self.consultant.status, 'draft')

--- a/apps/consultants/urls.py
+++ b/apps/consultants/urls.py
@@ -3,4 +3,5 @@ from . import views
 
 urlpatterns = [
     path('apply/', views.submit_application, name='submit_application'),
+    path('apply/draft/', views.autosave_consultant_draft, name='autosave_consultant_draft'),
 ]

--- a/apps/consultants/views.py
+++ b/apps/consultants/views.py
@@ -1,12 +1,41 @@
+import json
+
 from django.contrib import messages
+from django.http import JsonResponse
 from django.shortcuts import redirect, render
 from django.utils import timezone
+from django.utils.dateparse import parse_date
+from django.views.decorators.http import require_POST
 
 from .emails import send_submission_confirmation_email
 from .forms import ConsultantForm
 from .models import Consultant
 from apps.users.constants import UserRole as Roles
 from apps.users.permissions import role_required
+
+
+AUTO_SAVE_FIELDS = [
+    'full_name',
+    'id_number',
+    'dob',
+    'gender',
+    'nationality',
+    'email',
+    'phone_number',
+    'business_name',
+    'registration_number',
+]
+
+REQUIRED_AUTO_SAVE_FIELDS = [
+    'full_name',
+    'id_number',
+    'dob',
+    'gender',
+    'nationality',
+    'email',
+    'phone_number',
+    'business_name',
+]
 
 
 @role_required(Roles.CONSULTANT)
@@ -55,8 +84,115 @@ def submit_application(request):
 
             return redirect('dashboard')
 
+    show_save_draft = application is None or application.status == 'draft'
+
     return render(request, 'consultants/application_form.html', {
         'form': form,
         'is_editing': application is not None and application.status == 'draft',
-        'show_save_draft': application is None or application.status == 'draft',
+        'show_save_draft': show_save_draft,
+        'autosave_enabled': request.user.is_authenticated and show_save_draft,
+        'last_saved_at': application.updated_at if application else None,
     })
+
+
+@role_required(Roles.CONSULTANT)
+@require_POST
+def autosave_consultant_draft(request):
+    if not request.user.is_authenticated:
+        return JsonResponse({'status': 'error', 'message': 'Authentication required.'}, status=403)
+
+    try:
+        payload = json.loads(request.body.decode('utf-8') or '{}')
+    except json.JSONDecodeError:
+        return JsonResponse({'status': 'error', 'message': 'Invalid payload.'}, status=400)
+
+    consultant = Consultant.objects.filter(user=request.user).first()
+    now = timezone.now()
+    errors = {}
+
+    def cleaned_value(key):
+        value = payload.get(key, '')
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    if not consultant:
+        missing_required = [
+            field for field in REQUIRED_AUTO_SAVE_FIELDS if not cleaned_value(field)
+        ]
+        if missing_required:
+            return JsonResponse({
+                'status': 'skipped',
+                'message': 'Provide your personal and contact details to start auto-saving.',
+            })
+
+        consultant = Consultant(user=request.user)
+
+        for field in AUTO_SAVE_FIELDS:
+            if field == 'dob':
+                dob_value = cleaned_value(field)
+                parsed_dob = parse_date(dob_value) if dob_value else None
+                if not parsed_dob:
+                    errors[field] = 'Enter a valid date.'
+                    continue
+                consultant.dob = parsed_dob
+            elif field == 'registration_number':
+                optional_value = cleaned_value(field)
+                consultant.registration_number = optional_value or None
+            else:
+                setattr(consultant, field, cleaned_value(field))
+
+        if errors:
+            return JsonResponse({'status': 'error', 'errors': errors}, status=400)
+
+        consultant.status = 'draft'
+        consultant.save()
+        return JsonResponse({'status': 'saved', 'timestamp': now.isoformat()})
+
+    update_fields = set()
+
+    for field in AUTO_SAVE_FIELDS:
+        if field not in payload:
+            continue
+
+        if field == 'dob':
+            dob_value = cleaned_value(field)
+            if not dob_value:
+                continue
+            parsed_dob = parse_date(dob_value)
+            if not parsed_dob:
+                errors[field] = 'Enter a valid date.'
+                continue
+            if consultant.dob != parsed_dob:
+                consultant.dob = parsed_dob
+                update_fields.add('dob')
+        elif field == 'registration_number':
+            optional_value = cleaned_value(field)
+            new_value = optional_value or None
+            if consultant.registration_number != new_value:
+                consultant.registration_number = new_value
+                update_fields.add('registration_number')
+        else:
+            new_value = cleaned_value(field)
+            if not new_value:
+                continue
+            if getattr(consultant, field) != new_value:
+                setattr(consultant, field, new_value)
+                update_fields.add(field)
+
+    if errors:
+        return JsonResponse({'status': 'error', 'errors': errors}, status=400)
+
+    if not update_fields:
+        timestamp = consultant.updated_at.isoformat() if consultant.updated_at else now.isoformat()
+        return JsonResponse({'status': 'unchanged', 'timestamp': timestamp})
+
+    if consultant.status != 'draft':
+        consultant.status = 'draft'
+        update_fields.add('status')
+
+    consultant.updated_at = now
+    update_fields.add('updated_at')
+    consultant.save(update_fields=list(update_fields))
+
+    return JsonResponse({'status': 'saved', 'timestamp': now.isoformat()})

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -102,7 +102,29 @@
 .form-card form {
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 1.25rem;
+}
+
+.form-card .section {
+    margin-bottom: 0.5rem;
+    padding: 1rem;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    background-color: #fdfefe;
+}
+
+.form-card .section h3 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+    color: #333;
+    font-size: 1.05rem;
+    font-weight: 600;
+}
+
+.form-card .section .form-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
 }
 
 .form-card form p {
@@ -116,6 +138,15 @@
 .form-card label {
     color: #334155;
     font-weight: 500;
+}
+
+.draft-status {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    color: #1f2937;
+    background-color: rgba(37, 99, 235, 0.08);
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
 }
 
 .form-card input,
@@ -284,6 +315,21 @@
 .document-list a:hover,
 .document-list a:focus-visible {
     text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+    .form-card {
+        border-radius: 12px;
+        padding: clamp(1.25rem, 5vw, 1.75rem);
+    }
+
+    .form-card .section {
+        padding: 0.85rem;
+    }
+
+    .form-card .section h3 {
+        font-size: 1rem;
+    }
 }
 
 .message-list {

--- a/static/js/consultant_autosave.js
+++ b/static/js/consultant_autosave.js
@@ -1,0 +1,182 @@
+(function () {
+  const form = document.getElementById('consultant-form');
+  if (!form) {
+    return;
+  }
+
+  const autosaveUrl = form.dataset.autosaveUrl;
+  const lastSavedAt = form.dataset.lastSaved || '';
+  const statusElement = document.getElementById('draft-status');
+  const csrfInput = form.querySelector('input[name="csrfmiddlewaretoken"]');
+  const csrfToken = csrfInput ? csrfInput.value : '';
+
+  if (!autosaveUrl) {
+    return;
+  }
+
+  let inactivityTimer = null;
+  let isSaving = false;
+  let lastPayloadSignature = null;
+
+  const formatTimestamp = (isoString) => {
+    try {
+      const date = new Date(isoString);
+      if (Number.isNaN(date.getTime())) {
+        return null;
+      }
+      return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch (error) {
+      return null;
+    }
+  };
+
+  const updateStatus = (isoString) => {
+    if (!statusElement) {
+      return;
+    }
+
+    const formattedTime = formatTimestamp(isoString);
+    if (formattedTime) {
+      statusElement.textContent = `Draft saved at ${formattedTime}`;
+    } else {
+      statusElement.textContent = 'Draft saved.';
+    }
+  };
+
+  if (lastSavedAt) {
+    updateStatus(lastSavedAt);
+  }
+
+  const buildPayload = () => {
+    const payload = {};
+    const ignoredTypes = new Set(['file']);
+
+    Array.from(form.elements).forEach((element) => {
+      if (!(element instanceof HTMLElement)) {
+        return;
+      }
+
+      const { name, type } = element;
+      if (!name || ignoredTypes.has(type)) {
+        return;
+      }
+
+      if (type === 'checkbox') {
+        payload[name] = element.checked;
+      } else if (type === 'radio') {
+        if (element.checked) {
+          payload[name] = element.value;
+        } else if (!(name in payload)) {
+          payload[name] = '';
+        }
+      } else {
+        payload[name] = element.value;
+      }
+    });
+
+    payload.action = 'draft';
+    return payload;
+  };
+
+  const scheduleInactivitySave = () => {
+    if (inactivityTimer) {
+      window.clearTimeout(inactivityTimer);
+    }
+
+    inactivityTimer = window.setTimeout(() => {
+      void autoSave();
+    }, 15000);
+  };
+
+  const handleResponse = (result, signature) => {
+    if (!result) {
+      return;
+    }
+
+    if (result.status === 'saved') {
+      if (result.timestamp) {
+        updateStatus(result.timestamp);
+      }
+      lastPayloadSignature = signature;
+    } else if (result.status === 'unchanged') {
+      lastPayloadSignature = signature;
+    } else if (result.status === 'skipped') {
+      lastPayloadSignature = null;
+      if (statusElement && result.message) {
+        statusElement.textContent = result.message;
+      }
+    } else {
+      lastPayloadSignature = null;
+    }
+  };
+
+  const autoSave = async () => {
+    if (isSaving) {
+      return;
+    }
+
+    const payload = buildPayload();
+    const signature = JSON.stringify(payload);
+
+    if (signature === lastPayloadSignature) {
+      return;
+    }
+
+    isSaving = true;
+
+    try {
+      const response = await fetch(autosaveUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrfToken,
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        lastPayloadSignature = null;
+        return;
+      }
+
+      const result = await response.json();
+      handleResponse(result, signature);
+    } catch (error) {
+      lastPayloadSignature = null;
+    } finally {
+      isSaving = false;
+    }
+  };
+
+  form.addEventListener(
+    'blur',
+    (event) => {
+      if (!(event.target instanceof HTMLElement)) {
+        return;
+      }
+      if (!event.target.name) {
+        return;
+      }
+      void autoSave();
+    },
+    true,
+  );
+
+  form.addEventListener('input', () => {
+    scheduleInactivitySave();
+  });
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') {
+      void autoSave();
+    }
+  });
+
+  window.addEventListener('beforeunload', () => {
+    if (isSaving) {
+      return;
+    }
+    void autoSave();
+  });
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,5 +48,6 @@
         {% block content %}
         {% endblock %}
     </main>
+    {% block extra_scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/consultants/application_form.html
+++ b/templates/consultants/application_form.html
@@ -6,7 +6,11 @@
 <section class="form-card wide">
   <h1>{{ is_editing|yesno:"Update,Submit" }} consultant application</h1>
   <p class="description">Provide the required details so we can review and progress your consultant profile.</p>
-  <form method="post" enctype="multipart/form-data">
+  <form method="post" enctype="multipart/form-data" id="consultant-form"
+        {% if autosave_enabled %}
+        data-autosave-url="{% url 'autosave_consultant_draft' %}"
+        data-last-saved="{% if last_saved_at %}{{ last_saved_at|date:'c' }}{% endif %}"
+        {% endif %}>
     {% csrf_token %}
     {{ form.non_field_errors }}
 
@@ -39,8 +43,6 @@
       </div>
     </div>
 
-    <hr>
-
     <div class="section">
       <h3>Contact Details</h3>
       <div class="form-field">
@@ -54,9 +56,6 @@
         {{ form.phone_number.errors }}
       </div>
     </div>
-
-    <hr>
-
     <div class="section">
       <h3>Business Details</h3>
       <div class="form-field">
@@ -70,8 +69,6 @@
         {{ form.registration_number.errors }}
       </div>
     </div>
-
-    <hr>
 
     <div class="section">
       <h3>Required Uploads</h3>
@@ -107,6 +104,10 @@
       </div>
     </div>
 
+    {% if autosave_enabled %}
+    <div id="draft-status" class="draft-status" aria-live="polite"></div>
+    {% endif %}
+
     <div class="form-actions">
       {% if show_save_draft %}
         <button type="submit" name="action" value="draft" class="btn-secondary">Save draft</button>
@@ -118,4 +119,11 @@
     <a href="{% url 'dashboard' %}">Back to dashboard</a>
   </div>
 </section>
+{% endblock %}
+
+{% block extra_scripts %}
+  {{ block.super }}
+  {% if autosave_enabled %}
+    <script src="{% static 'js/consultant_autosave.js' %}"></script>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- style the consultant application form sections with refreshed layout and draft status messaging
- add an authenticated AJAX draft auto-save endpoint and browser script that persists changes while users fill the form
- cover the auto-save workflow with a unit test to ensure only edited fields are updated

## Testing
- pytest apps/consultants/tests.py *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68e6099ba01083269a229b365b13ffa0