### PR TITLE
Fix dependency conflicts in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,11 @@ packaging==25.0
 pillow==11.3.0
 psycopg2-binary==2.9.10
 Pygments==2.19.2
+PyJWT==2.9.0
 pytest==8.4.2
+pytest-django==4.9.0
 pytest-mock==3.15.1
-sentry-sdk==2.40.0
+sentry-sdk[django]==2.40.0
 sqlparse==0.5.3
 urllib3==2.5.0
 whitenoise==6.11.0
-sentry-sdk[django]==1.45.0
-pytest==8.4.1
-pytest-django==4.9.0
-pytest-mock==3.14.0


### PR DESCRIPTION
## Summary
- deduplicate conflicting dependency pins in requirements.txt to allow dependency resolution
- add PyJWT dependency required by tests and runtime components

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e60e72a3e08326bbb85a0aa1e2fff6