### PR TITLE
Add multi-step wizard to consultant application form

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -105,6 +105,93 @@
     gap: 1.25rem;
 }
 
+.wizard {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.wizard-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.wizard-step-counter {
+    margin: 0;
+    font-weight: 600;
+    color: #1d4ed8;
+    font-size: 0.95rem;
+}
+
+.wizard-progress-list {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+}
+
+.wizard-progress-item {
+    flex: 1 1 200px;
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.65rem 0.85rem;
+    border-radius: 12px;
+    background: rgba(37, 99, 235, 0.08);
+    color: #1e3a8a;
+    font-weight: 600;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.wizard-progress-item .wizard-progress-marker {
+    width: 1.75rem;
+    height: 1.75rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    background-color: rgba(37, 99, 235, 0.18);
+    font-size: 0.85rem;
+}
+
+.wizard-progress-item[aria-current="step"],
+.wizard-progress-item.is-active {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.22), rgba(37, 99, 235, 0.32));
+    color: #1d4ed8;
+}
+
+.wizard-progress-item[aria-current="step"] .wizard-progress-marker,
+.wizard-progress-item.is-active .wizard-progress-marker {
+    background-color: #1d4ed8;
+    color: #ffffff;
+}
+
+.wizard-step-title {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-size: 1.1rem;
+}
+
+.wizard-step-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.wizard-navigation {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.wizard-navigation .wizard-prev[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .form-card .section {
     margin-bottom: 0.5rem;
     padding: 1rem;

--- a/static/js/consultant_autosave.js
+++ b/static/js/consultant_autosave.js
@@ -149,6 +149,10 @@
     }
   };
 
+  form.addEventListener('consultant:auto-save', () => {
+    void autoSave();
+  });
+
   form.addEventListener(
     'blur',
     (event) => {

--- a/static/js/consultant_wizard.js
+++ b/static/js/consultant_wizard.js
@@ -1,0 +1,176 @@
+(function () {
+  const form = document.getElementById('consultant-form');
+  if (!form) {
+    return;
+  }
+
+  const steps = Array.from(form.querySelectorAll('.wizard-step'));
+  const progressItems = Array.from(form.querySelectorAll('.wizard-progress-item'));
+  const stepCounter = form.querySelector('#wizard-step-counter');
+  const prevButton = form.querySelector('.wizard-prev');
+  const nextButton = form.querySelector('.wizard-next');
+  const finalActions = form.querySelector('[data-final-actions]');
+  const totalSteps = steps.length;
+
+  if (!totalSteps || !prevButton || !nextButton) {
+    return;
+  }
+
+  let currentStepIndex = steps.findIndex((step) => !step.hasAttribute('hidden'));
+  if (currentStepIndex < 0) {
+    currentStepIndex = 0;
+  }
+
+  const focusStep = (step) => {
+    if (!step) {
+      return;
+    }
+
+    window.requestAnimationFrame(() => {
+      const focusTarget =
+        step.querySelector('[data-step-focus]') ||
+        step.querySelector('input, select, textarea, button, [tabindex]:not([tabindex="-1"])');
+
+      if (focusTarget) {
+        const previousTabIndex = focusTarget.getAttribute('tabindex');
+        if (previousTabIndex === null) {
+          focusTarget.setAttribute('tabindex', '-1');
+        }
+        focusTarget.focus({ preventScroll: false });
+        if (previousTabIndex === null) {
+          focusTarget.removeAttribute('tabindex');
+        }
+      }
+    });
+  };
+
+  const updateStepCounter = () => {
+    if (!stepCounter) {
+      return;
+    }
+
+    stepCounter.textContent = `Step ${currentStepIndex + 1} of ${totalSteps}`;
+  };
+
+  const updateProgress = () => {
+    progressItems.forEach((item, index) => {
+      if (index === currentStepIndex) {
+        item.setAttribute('aria-current', 'step');
+        item.classList.add('is-active');
+      } else {
+        item.removeAttribute('aria-current');
+        item.classList.remove('is-active');
+      }
+    });
+  };
+
+  const updateNavigation = () => {
+    const isFirstStep = currentStepIndex === 0;
+    const isLastStep = currentStepIndex === totalSteps - 1;
+
+    prevButton.disabled = isFirstStep;
+    prevButton.setAttribute('aria-disabled', isFirstStep ? 'true' : 'false');
+
+    if (isLastStep) {
+      nextButton.hidden = true;
+      nextButton.setAttribute('aria-hidden', 'true');
+    } else {
+      nextButton.hidden = false;
+      nextButton.removeAttribute('aria-hidden');
+      if (currentStepIndex === totalSteps - 2) {
+        nextButton.textContent = 'Review & submit';
+      } else {
+        nextButton.textContent = 'Next step';
+      }
+    }
+
+    if (finalActions) {
+      if (isLastStep) {
+        finalActions.hidden = false;
+      } else {
+        finalActions.hidden = true;
+      }
+    }
+  };
+
+  const triggerAutoSave = () => {
+    const autoSaveEvent = new CustomEvent('consultant:auto-save', { bubbles: true });
+    form.dispatchEvent(autoSaveEvent);
+  };
+
+  const updateStepsVisibility = (triggerSave = false, shouldFocus = true) => {
+    steps.forEach((step, index) => {
+      if (index === currentStepIndex) {
+        step.removeAttribute('hidden');
+        step.classList.add('is-active');
+      } else {
+        step.setAttribute('hidden', 'hidden');
+        step.classList.remove('is-active');
+      }
+    });
+
+    updateProgress();
+    updateStepCounter();
+    updateNavigation();
+    if (shouldFocus) {
+      focusStep(steps[currentStepIndex]);
+    }
+
+    if (triggerSave) {
+      triggerAutoSave();
+    }
+  };
+
+  const validateCurrentStep = () => {
+    const currentStep = steps[currentStepIndex];
+    if (!currentStep) {
+      return true;
+    }
+
+    const fields = Array.from(
+      currentStep.querySelectorAll('input, select, textarea'),
+    ).filter((field) => !field.disabled && field.offsetParent !== null);
+
+    for (const field of fields) {
+      if (!field.checkValidity()) {
+        field.reportValidity();
+        field.focus();
+        return false;
+      }
+    }
+
+    return true;
+  };
+
+  const goToStep = (newIndex) => {
+    if (newIndex < 0 || newIndex >= totalSteps || newIndex === currentStepIndex) {
+      return;
+    }
+
+    currentStepIndex = newIndex;
+    updateStepsVisibility(true, true);
+  };
+
+  prevButton.addEventListener('click', () => {
+    if (currentStepIndex === 0) {
+      return;
+    }
+    goToStep(currentStepIndex - 1);
+  });
+
+  nextButton.addEventListener('click', () => {
+    if (!validateCurrentStep()) {
+      return;
+    }
+
+    goToStep(currentStepIndex + 1);
+  });
+
+  form.addEventListener('submit', () => {
+    if (finalActions && finalActions.hidden) {
+      finalActions.hidden = false;
+    }
+  });
+
+  updateStepsVisibility(false, false);
+})();

--- a/templates/consultants/application_form.html
+++ b/templates/consultants/application_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load static %}
 
 {% block title %}{{ is_editing|yesno:"Edit,Submit" }} Consultant Application{% endblock %}
 
@@ -13,94 +14,127 @@
         {% endif %}>
     {% csrf_token %}
     {{ form.non_field_errors }}
+    <div class="wizard" data-total-steps="4">
+      <header class="wizard-header">
+        <p id="wizard-step-counter" class="wizard-step-counter" aria-live="polite">Step 1 of 4</p>
+        <nav class="wizard-progress" aria-label="Application progress">
+          <ol class="wizard-progress-list">
+            <li class="wizard-progress-item" data-step="1" aria-current="step">
+              <span class="wizard-progress-marker" aria-hidden="true">1</span>
+              <span class="wizard-progress-label">Personal Details</span>
+            </li>
+            <li class="wizard-progress-item" data-step="2">
+              <span class="wizard-progress-marker" aria-hidden="true">2</span>
+              <span class="wizard-progress-label">Contact Information</span>
+            </li>
+            <li class="wizard-progress-item" data-step="3">
+              <span class="wizard-progress-marker" aria-hidden="true">3</span>
+              <span class="wizard-progress-label">Business Information</span>
+            </li>
+            <li class="wizard-progress-item" data-step="4">
+              <span class="wizard-progress-marker" aria-hidden="true">4</span>
+              <span class="wizard-progress-label">Required Documents</span>
+            </li>
+          </ol>
+        </nav>
+      </header>
 
-    <div class="section">
-      <h3>Personal Details</h3>
-      <div class="form-field">
-        {{ form.full_name.label_tag }}
-        {{ form.full_name }}
-        {{ form.full_name.errors }}
-      </div>
-      <div class="form-field">
-        {{ form.id_number.label_tag }}
-        {{ form.id_number }}
-        {{ form.id_number.errors }}
-      </div>
-      <div class="form-field">
-        {{ form.dob.label_tag }}
-        {{ form.dob }}
-        {{ form.dob.errors }}
-      </div>
-      <div class="form-field">
-        {{ form.gender.label_tag }}
-        {{ form.gender }}
-        {{ form.gender.errors }}
-      </div>
-      <div class="form-field">
-        {{ form.nationality.label_tag }}
-        {{ form.nationality }}
-        {{ form.nationality.errors }}
-      </div>
-    </div>
+      <div class="wizard-step-container">
+        <section class="section wizard-step" data-step="1" aria-labelledby="wizard-step-1-title">
+          <h2 id="wizard-step-1-title" class="wizard-step-title" tabindex="-1" data-step-focus>Personal Details</h2>
+          <div class="form-field">
+            {{ form.full_name.label_tag }}
+            {{ form.full_name }}
+            {{ form.full_name.errors }}
+          </div>
+          <div class="form-field">
+            {{ form.id_number.label_tag }}
+            {{ form.id_number }}
+            {{ form.id_number.errors }}
+          </div>
+          <div class="form-field">
+            {{ form.dob.label_tag }}
+            {{ form.dob }}
+            {{ form.dob.errors }}
+          </div>
+          <div class="form-field">
+            {{ form.gender.label_tag }}
+            {{ form.gender }}
+            {{ form.gender.errors }}
+          </div>
+          <div class="form-field">
+            {{ form.nationality.label_tag }}
+            {{ form.nationality }}
+            {{ form.nationality.errors }}
+          </div>
+        </section>
 
-    <div class="section">
-      <h3>Contact Details</h3>
-      <div class="form-field">
-        {{ form.email.label_tag }}
-        {{ form.email }}
-        {{ form.email.errors }}
-      </div>
-      <div class="form-field">
-        {{ form.phone_number.label_tag }}
-        {{ form.phone_number }}
-        {{ form.phone_number.errors }}
-      </div>
-    </div>
-    <div class="section">
-      <h3>Business Details</h3>
-      <div class="form-field">
-        {{ form.business_name.label_tag }}
-        {{ form.business_name }}
-        {{ form.business_name.errors }}
-      </div>
-      <div class="form-field">
-        {{ form.registration_number.label_tag }}
-        {{ form.registration_number }}
-        {{ form.registration_number.errors }}
-      </div>
-    </div>
+        <section class="section wizard-step" data-step="2" aria-labelledby="wizard-step-2-title" hidden>
+          <h2 id="wizard-step-2-title" class="wizard-step-title" tabindex="-1" data-step-focus>Contact Information</h2>
+          <div class="form-field">
+            {{ form.email.label_tag }}
+            {{ form.email }}
+            {{ form.email.errors }}
+          </div>
+          <div class="form-field">
+            {{ form.phone_number.label_tag }}
+            {{ form.phone_number }}
+            {{ form.phone_number.errors }}
+          </div>
+        </section>
 
-    <div class="section">
-      <h3>Required Uploads</h3>
-      <div class="form-field">
-        {{ form.photo.label_tag }}
-        {{ form.photo }}
-        {{ form.photo.errors }}
+        <section class="section wizard-step" data-step="3" aria-labelledby="wizard-step-3-title" hidden>
+          <h2 id="wizard-step-3-title" class="wizard-step-title" tabindex="-1" data-step-focus>Business Information</h2>
+          <div class="form-field">
+            {{ form.business_name.label_tag }}
+            {{ form.business_name }}
+            {{ form.business_name.errors }}
+          </div>
+          <div class="form-field">
+            {{ form.registration_number.label_tag }}
+            {{ form.registration_number }}
+            {{ form.registration_number.errors }}
+          </div>
+        </section>
+
+        <section class="section wizard-step" data-step="4" aria-labelledby="wizard-step-4-title" hidden>
+          <h2 id="wizard-step-4-title" class="wizard-step-title" tabindex="-1" data-step-focus>Required Documents</h2>
+          <div class="form-field">
+            {{ form.photo.label_tag }}
+            {{ form.photo }}
+            {{ form.photo.errors }}
+          </div>
+          <div class="form-field">
+            {{ form.id_document.label_tag }}
+            {{ form.id_document }}
+            {{ form.id_document.errors }}
+          </div>
+          <div class="form-field">
+            {{ form.cv.label_tag }}
+            {{ form.cv }}
+            {{ form.cv.errors }}
+          </div>
+          <div class="form-field">
+            {{ form.police_clearance.label_tag }}
+            {{ form.police_clearance }}
+            {{ form.police_clearance.errors }}
+          </div>
+          <div class="form-field">
+            {{ form.qualifications.label_tag }}
+            {{ form.qualifications }}
+            {{ form.qualifications.errors }}
+          </div>
+          <div class="form-field">
+            {{ form.business_certificate.label_tag }}
+            {{ form.business_certificate }}
+            {{ form.business_certificate.errors }}
+          </div>
+        </section>
       </div>
-      <div class="form-field">
-        {{ form.id_document.label_tag }}
-        {{ form.id_document }}
-        {{ form.id_document.errors }}
-      </div>
-      <div class="form-field">
-        {{ form.cv.label_tag }}
-        {{ form.cv }}
-        {{ form.cv.errors }}
-      </div>
-      <div class="form-field">
-        {{ form.police_clearance.label_tag }}
-        {{ form.police_clearance }}
-        {{ form.police_clearance.errors }}
-      </div>
-      <div class="form-field">
-        {{ form.qualifications.label_tag }}
-        {{ form.qualifications }}
-        {{ form.qualifications.errors }}
-      </div>
-      <div class="form-field">
-        {{ form.business_certificate.label_tag }}
-        {{ form.business_certificate }}
-        {{ form.business_certificate.errors }}
+
+      <div class="wizard-navigation">
+        <button type="button" class="btn-secondary wizard-prev" data-direction="prev" disabled>Previous</button>
+        <button type="button" class="btn-primary wizard-next" data-direction="next">Next step</button>
       </div>
     </div>
 
@@ -108,7 +142,7 @@
     <div id="draft-status" class="draft-status" aria-live="polite"></div>
     {% endif %}
 
-    <div class="form-actions">
+    <div class="form-actions" data-final-actions hidden>
       {% if show_save_draft %}
         <button type="submit" name="action" value="draft" class="btn-secondary">Save draft</button>
       {% endif %}
@@ -123,6 +157,7 @@
 
 {% block extra_scripts %}
   {{ block.super }}
+  <script src="{% static 'js/consultant_wizard.js' %}"></script>
   {% if autosave_enabled %}
     <script src="{% static 'js/consultant_autosave.js' %}"></script>
   {% endif %}


### PR DESCRIPTION
## Summary
- refactor the consultant application template into four wizard steps with a progress indicator and staged actions
- add client-side wizard controller that manages validation, focus changes, navigation, and autosave triggers
- style the wizard layout and extend the autosave script to respond to step-change save events

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e61414c9cc8326870b9db44b805c1f