### PR TITLE
Add CSV export to staff dashboard

### DIFF
--- a/apps/users/templates/staff_dashboard.html
+++ b/apps/users/templates/staff_dashboard.html
@@ -131,7 +131,15 @@
 
   <section class="card">
     <div class="card-body">
-      <h2 class="h4 mb-3">{{ active_status_label }} Consultant Applications</h2>
+      <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2 mb-3">
+        <h2 class="h4 mb-0">{{ active_status_label }} Consultant Applications</h2>
+        <a
+          class="btn btn-outline-primary"
+          href="{% url 'staff_dashboard_export' %}{% if base_querystring %}?{{ base_querystring }}{% endif %}"
+        >
+          Export CSV
+        </a>
+      </div>
 
       {% if page_obj.object_list %}
         <p class="text-muted">Select an action for each application and optionally leave an internal comment.</p>

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -3,6 +3,7 @@ from . import views
 from .views import (
     RoleBasedLoginView,
     home_view,
+    staff_dashboard_export_csv,
     staff_consultant_detail,
     staff_dashboard,
 )
@@ -13,6 +14,7 @@ urlpatterns = [
     path('register/', views.register, name='register'),
     path('dashboard/', views.dashboard, name='dashboard'),
     path('staff-dashboard/', staff_dashboard, name='staff_dashboard'),
+    path('staff-dashboard/export/', staff_dashboard_export_csv, name='staff_dashboard_export'),
     path('staff/consultant/<int:pk>/', staff_consultant_detail, name='staff_consultant_detail'),
     path('board/', views.board_dashboard, name='board_dashboard'),
     path('impersonation/', views.impersonation_dashboard, name='impersonation_dashboard'),


### PR DESCRIPTION
## Summary
- add shared utilities for building the staff dashboard consultant queryset
- expose a CSV export endpoint and link from the staff dashboard UI
- cover CSV export filtering and permissions with new tests

## Testing
- pytest apps/users/tests.py::StaffDashboardExportTests -q --import-mode=importlib


------
https://chatgpt.com/codex/tasks/task_e_68e626491dec83268a590d2f4f80b49e