### PR TITLE
Add PDF export for consultant applications

### DIFF
--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -2,7 +2,9 @@ from django.urls import path
 from . import views
 from .views import (
     RoleBasedLoginView,
+    consultant_application_pdf,
     home_view,
+    staff_consultant_pdf,
     staff_dashboard_export_csv,
     staff_consultant_detail,
     staff_dashboard,
@@ -16,6 +18,8 @@ urlpatterns = [
     path('staff-dashboard/', staff_dashboard, name='staff_dashboard'),
     path('staff-dashboard/export/', staff_dashboard_export_csv, name='staff_dashboard_export'),
     path('staff/consultant/<int:pk>/', staff_consultant_detail, name='staff_consultant_detail'),
+    path('staff/consultant/<int:pk>/pdf/', staff_consultant_pdf, name='staff_consultant_pdf'),
+    path('consultant/application/pdf/', consultant_application_pdf, name='consultant_application_pdf'),
     path('board/', views.board_dashboard, name='board_dashboard'),
     path('impersonation/', views.impersonation_dashboard, name='impersonation_dashboard'),
     path('impersonation/start/', views.start_impersonation, name='start_impersonation'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pillow==11.3.0
 psycopg2-binary==2.9.10
 Pygments==2.19.2
 PyJWT==2.9.0
+WeasyPrint==62.3
 pytest==8.4.2
 pytest-django==4.9.0
 pytest-mock==3.15.1

--- a/templates/consultants/application_pdf.html
+++ b/templates/consultants/application_pdf.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Consultant Application - {{ consultant.full_name }}</title>
+  <style>
+    body {
+      font-family: "Helvetica", "Arial", sans-serif;
+      font-size: 12pt;
+      color: #1a1a1a;
+      margin: 1.5cm;
+    }
+
+    header {
+      border-bottom: 2px solid #0b5394;
+      padding-bottom: 12px;
+      margin-bottom: 24px;
+    }
+
+    h1 {
+      font-size: 20pt;
+      margin: 0 0 4px 0;
+      color: #0b5394;
+    }
+
+    h2 {
+      font-size: 14pt;
+      margin: 24px 0 8px 0;
+      color: #0b5394;
+    }
+
+    dl {
+      display: grid;
+      grid-template-columns: 30% 70%;
+      column-gap: 12px;
+      row-gap: 8px;
+    }
+
+    dt {
+      font-weight: bold;
+    }
+
+    ul {
+      padding-left: 18px;
+      margin: 8px 0;
+    }
+
+    li {
+      margin-bottom: 6px;
+    }
+
+    .meta {
+      font-size: 10pt;
+      color: #555;
+    }
+
+    .section {
+      page-break-inside: avoid;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Consultant Application</h1>
+    <p class="meta">
+      Applicant: {{ consultant.full_name }} &bull;
+      Application ID: {{ consultant.id }} &bull;
+      Status: {{ consultant.get_status_display }}
+      {% if consultant.submitted_at %}&bull; Submitted {{ consultant.submitted_at|date:"F j, Y" }}{% endif %}
+    </p>
+    <p class="meta">Generated on {{ generated_at|date:"F j, Y, g:i a" }}</p>
+  </header>
+
+  <section class="section">
+    <h2>Personal information</h2>
+    <dl>
+      <dt>Full name</dt>
+      <dd>{{ consultant.full_name }}</dd>
+
+      <dt>ID number</dt>
+      <dd>{{ consultant.id_number }}</dd>
+
+      <dt>Date of birth</dt>
+      <dd>{{ consultant.dob|date:"F j, Y" }}</dd>
+
+      <dt>Gender</dt>
+      <dd>{{ consultant.get_gender_display }}</dd>
+
+      <dt>Nationality</dt>
+      <dd>{{ consultant.nationality }}</dd>
+
+      <dt>Email</dt>
+      <dd>{{ consultant.email }}</dd>
+
+      <dt>Phone number</dt>
+      <dd>{{ consultant.phone_number }}</dd>
+    </dl>
+  </section>
+
+  <section class="section">
+    <h2>Business information</h2>
+    <dl>
+      <dt>Business name</dt>
+      <dd>{{ consultant.business_name }}</dd>
+
+      <dt>Registration number</dt>
+      <dd>{% if consultant.registration_number %}{{ consultant.registration_number }}{% else %}Not provided{% endif %}</dd>
+    </dl>
+  </section>
+
+  <section class="section">
+    <h2>Submitted documents</h2>
+    {% if document_fields %}
+      <ul>
+        {% for document in document_fields %}
+          <li>
+            <strong>{{ document.label }}</strong><br />
+            {{ document.name }} ({{ document.type }}, {{ document.size }})
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>No supporting documents submitted.</p>
+    {% endif %}
+  </section>
+
+  <section class="section">
+    <h2>Decision documents</h2>
+    {% if decision_documents %}
+      <ul>
+        {% for document in decision_documents %}
+          <li>
+            <strong>{{ document.label }}</strong><br />
+            {{ document.name }} ({{ document.type }}, {{ document.size }})
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>No decision documents available.</p>
+    {% endif %}
+  </section>
+
+  {% if consultant.staff_comment %}
+  <section class="section">
+    <h2>Staff comment</h2>
+    <p>{{ consultant.staff_comment }}</p>
+  </section>
+  {% endif %}
+</body>
+</html>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -48,20 +48,25 @@
       </li>
     </ul>
 
+    <div class="form-actions">
+      <a class="btn-secondary" href="{% url 'consultant_application_pdf' %}">Download PDF</a>
+    </div>
+
     {% if document_fields %}
     <h4>Submitted documents</h4>
     <ul class="document-list">
       {% for document in document_fields %}
-      <li>{{ document.label }} — <a href="{{ document.file.url }}" target="_blank" rel="noopener">Download</a></li>
+      <li>{{ document.label }} — <a href="{{ document.url }}" target="_blank" rel="noopener">Download</a></li>
       {% endfor %}
     </ul>
     {% endif %}
 
-    {% if application.certificate_pdf or application.rejection_letter %}
+    {% if decision_documents %}
     <h4>Decision documents</h4>
     <ul class="document-list">
-      {% if application.certificate_pdf %}<li>Approval certificate — <a href="{{ application.certificate_pdf.url }}" target="_blank" rel="noopener">Download</a></li>{% endif %}
-      {% if application.rejection_letter %}<li>Rejection letter — <a href="{{ application.rejection_letter.url }}" target="_blank" rel="noopener">Download</a></li>{% endif %}
+      {% for document in decision_documents %}
+      <li>{{ document.label }} — <a href="{{ document.url }}" target="_blank" rel="noopener">Download</a></li>
+      {% endfor %}
     </ul>
     {% endif %}
 

--- a/templates/staff/consultant_detail.html
+++ b/templates/staff/consultant_detail.html
@@ -10,14 +10,17 @@
     </ol>
   </nav>
 
-  <header class="mb-4">
-    <h1 class="h3 mb-1">{{ consultant.full_name }}</h1>
-    <p class="mb-0 text-muted">
-      Application #{{ consultant.id }} · Status: {{ consultant.get_status_display }}
-      {% if consultant.submitted_at %}
-        · Submitted {{ consultant.submitted_at|date:"M d, Y" }}
-      {% endif %}
-    </p>
+  <header class="mb-4 d-flex flex-column flex-lg-row align-items-lg-center justify-content-lg-between gap-3">
+    <div>
+      <h1 class="h3 mb-1">{{ consultant.full_name }}</h1>
+      <p class="mb-0 text-muted">
+        Application #{{ consultant.id }} · Status: {{ consultant.get_status_display }}
+        {% if consultant.submitted_at %}
+          · Submitted {{ consultant.submitted_at|date:"M d, Y" }}
+        {% endif %}
+      </p>
+    </div>
+    <a href="{% url 'staff_consultant_pdf' consultant.pk %}" class="btn btn-primary">Download PDF</a>
   </header>
 
   <section class="card mb-4">
@@ -81,6 +84,23 @@
       {% endif %}
     </div>
   </section>
+
+  {% if decision_documents %}
+    <section class="card mb-4">
+      <div class="card-body">
+        <h2 class="h5 mb-3">Decision documents</h2>
+        <ul class="list-unstyled mb-0">
+          {% for document in decision_documents %}
+            <li class="mb-2">
+              <span class="fw-semibold d-block">{{ document.label }}</span>
+              <a href="{{ document.url }}" target="_blank" rel="noopener">{{ document.name }}</a>
+              <small class="text-muted d-block">{{ document.type }} · {{ document.size }}</small>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </section>
+  {% endif %}
 
   {% if consultant.staff_comment %}
     <section class="card mb-4">


### PR DESCRIPTION
## Summary
- add reusable helpers for consultant documents and generate PDFs with WeasyPrint
- expose PDF download endpoints for staff and consultants and surface buttons in the UI
- cover PDF access rules with automated tests and include a printable HTML template

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e62ab7eef88326a9ea50d6752ceb9c